### PR TITLE
 append plugin autoPrefix to default prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,68 @@ fastify.register(AutoLoad, {
 ```
 *Note that options will be passed to all loaded plugins.*
 
+You can set the prefix option in the options passed to all plugins to set them all default prefix.
+When plugins get passed `prefix` as a default option, the `autoPrefix` property gets appended to them.
+This means you can load all plugins in a folder with a default prefix.
+
+```js
+// index.js
+fastify.register(AutoLoad, {
+  dir: path.join(__dirname, 'foo'),
+  options: { prefix: '/defaultPrefix' }
+})
+
+// /foo/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
+
+// optional
+module.exports.autoPrefix = '/something'
+
+// routes can now be added to /defaultPrefix/something
+```
+
+If you have a plugin in the folder you don't want the default prefix applied to, you can add the `prefixOverride` key:
+
+```js
+// index.js
+fastify.register(AutoLoad, {
+  dir: path.join(__dirname, 'foo'),
+  options: { prefix: '/defaultPrefix' }
+})
+
+// /foo/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
+
+// optional
+module.exports.prefixOverride = '/overriddenPrefix'
+
+// routes can now be added to /overriddenPrefix
+```
+
+If you have a plugin in the folder you don't want the any prefix applied to, you can set `prefixOverride = ''`:
+
+```js
+// index.js
+fastify.register(AutoLoad, {
+  dir: path.join(__dirname, 'foo'),
+  options: { prefix: '/defaultPrefix' }
+})
+
+// /foo/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
+
+// optional
+module.exports.prefixOverride = ''
+
+// routes can now be added without a prefix
+```
+
 ## License
 
 MIT

--- a/fixtures/app.js
+++ b/fixtures/app.js
@@ -8,5 +8,11 @@ module.exports = function (fastify, opts, next) {
     dir: path.join(__dirname, 'foo'),
     options: { foo: 'bar' }
   })
+
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'defaultPrefix'),
+    options: { prefix: '/defaultPrefix' }
+  })
+
   next()
 }

--- a/fixtures/defaultPrefix/defaultPrefix.js
+++ b/fixtures/defaultPrefix/defaultPrefix.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ index: true })
+  })
+
+  next()
+}

--- a/fixtures/defaultPrefix/noDefaultPrefix.js
+++ b/fixtures/defaultPrefix/noDefaultPrefix.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/noPrefix', (request, reply) => {
+    reply.send({ no: 'prefix' })
+  })
+
+  next()
+}
+
+module.exports.prefixOverride = ''

--- a/fixtures/defaultPrefix/overridePrefix.js
+++ b/fixtures/defaultPrefix/overridePrefix.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ overide: 'prefix' })
+  })
+
+  next()
+}
+
+module.exports.autoPrefix = '/notUsed'
+
+module.exports.prefixOverride = '/overriddenPrefix'

--- a/fixtures/defaultPrefix/prefixed.js
+++ b/fixtures/defaultPrefix/prefixed.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ prefixed: true })
+  })
+
+  next()
+}
+
+module.exports.autoPrefix = '/prefixed'

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const path = require('path')
 const steed = require('steed')
 
 module.exports = function (fastify, opts, next) {
-  const pluginOptions = opts.options || {}
+  const defaultPluginOptions = opts.options || {}
   fs.readdir(opts.dir, function (err, list) {
     if (err) {
       next(err)
@@ -38,13 +38,17 @@ module.exports = function (fastify, opts, next) {
         if (stat.isFile() || stat.isDirectory()) {
           try {
             const plugin = require(file)
-            const opts = {}
+            const pluginOptions = {}
+            Object.assign(pluginOptions, defaultPluginOptions)
             if (plugin.autoPrefix) {
-              opts.prefix = plugin.autoPrefix
+              const prefix = pluginOptions.prefix ? pluginOptions.prefix : ''
+              pluginOptions.prefix = prefix + plugin.autoPrefix
             }
-            Object.assign(opts, pluginOptions)
+            if (plugin.prefixOverride) {
+              pluginOptions.prefix = plugin.prefixOverride
+            }
             if (plugin.autoload !== false) {
-              fastify.register(plugin, opts)
+              fastify.register(plugin, pluginOptions)
             }
           } catch (err) {
             next(err)

--- a/index.js
+++ b/index.js
@@ -41,10 +41,10 @@ module.exports = function (fastify, opts, next) {
             const pluginOptions = {}
             Object.assign(pluginOptions, defaultPluginOptions)
             if (plugin.autoPrefix) {
-              const prefix = pluginOptions.prefix ? pluginOptions.prefix : ''
+              const prefix = pluginOptions.prefix || ''
               pluginOptions.prefix = prefix + plugin.autoPrefix
             }
-            if (plugin.prefixOverride) {
+            if (plugin.prefixOverride !== void 0) {
               pluginOptions.prefix = plugin.prefixOverride
             }
             if (plugin.autoload !== false) {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(15)
+t.plan(29)
 
 const app = Fastify()
 
@@ -54,5 +54,44 @@ app.ready(function (err) {
     t.deepEqual(JSON.parse(res.payload), {
       foo: 'bar'
     })
+  })
+
+  app.inject({
+    url: '/defaultPrefix'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { index: true })
+  })
+
+  app.inject({
+    url: '/defaultPrefix/prefixed'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { prefixed: true })
+  })
+
+  app.inject({
+    url: '/defaultPrefix/overriddenPrefix'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 404)
+  })
+
+  app.inject({
+    url: '/overriddenPrefix'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { overide: 'prefix' })
+  })
+
+  app.inject({
+    url: '/noPrefix'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { no: 'prefix' })
   })
 })


### PR DESCRIPTION
Using `prefix` in the default autoload options should apply a prefix for all plugins loaded by this module. This makes it so any modules then loaded by autoload appends the modules autoPrefix to the end of the default autoload prefix.

It also adds a prefixOverride to override the defaultPrefix (and autoPrefix).

I hope this is okay!