### PR TITLE
Load multiple modules from a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,40 @@ fastify.register(AutoLoad, {
 })
 ```
 
+fastify-autoload loads folders with route definitions automatically, without explicitly registering them. The folder name is used as default prefix for all files in that folder, unless otherwise specified in an `index.js`. See "module.exports.autoPrefix" on how to overwrite this behaviour.
+
+```js
+// index.js
+fastify.register(AutoLoad, {
+  dir: path.join(__dirname, 'services'),
+  options: {}
+})
+
+// /services/items/get.js
+module.exports = function (f, opts, next) {
+  f.get('/:id', (request, reply) => {
+    reply.send({ answer: 42 })
+  })
+
+  next()
+}
+
+// /services/items/list.js
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send([0, 1, 2])
+  })
+
+  next()
+}
+
+/**
+ * Routes generated:
+ * GET /items
+ * GET /items/:id
+ */
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ module.exports = function (fastify, opts, next) {
               for (let index = 0; index < files.length; index++) {
                 const file = files[index]
 
+                // windows debugging
+                console.log(file)
+                console.log(toLoad)
+                console.log(toLoad.split('/').pop())
+                // end windows debugging
+
                 plugins.push({
                   skip: !file.match(/.js$/),
                   opts: {

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function (fastify, opts, next) {
             // if the directory contains files but no index.js, load them as independend plugins
             if (
               files.indexOf('index.js') === -1 &&
+              files.indexOf('package.json') === -1 &&
               files.toString().indexOf('.js') > -1
             ) {
               let plugins = []

--- a/index.js
+++ b/index.js
@@ -56,13 +56,13 @@ module.exports = function (fastify, opts, next) {
                 // windows debugging
                 console.log(file)
                 console.log(toLoad)
-                console.log(toLoad.split('/').pop())
+                console.log(toLoad.split(path.sep).pop())
                 // end windows debugging
 
                 plugins.push({
                   skip: !file.match(/.js$/),
                   opts: {
-                    prefix: toLoad.split('/').pop()
+                    prefix: toLoad.split(path.sep).pop()
                   },
                   file: path.join(toLoad, file)
                 })

--- a/index.js
+++ b/index.js
@@ -55,6 +55,9 @@ module.exports = function (fastify, opts, next) {
 
                 plugins.push({
                   skip: !file.match(/.js$/),
+                  opts: {
+                    prefix: toLoad.split('/').pop()
+                  },
                   file: path.join(toLoad, file)
                 })
               }
@@ -86,7 +89,7 @@ module.exports = function (fastify, opts, next) {
       const allPlugins = {}
 
       for (let i = 0; i < stats.length; i++) {
-        const { skip, file } = stats[i]
+        const { skip, file, opts } = stats[i]
 
         if (skip) {
           continue
@@ -97,6 +100,10 @@ module.exports = function (fastify, opts, next) {
           const pluginOptions = Object.assign({}, defaultPluginOptions)
           const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
           const pluginName = pluginMeta.name || file
+
+          if (opts && !plugin.autoPrefix) {
+            plugin.autoPrefix = opts.prefix
+          }
 
           if (plugin.autoload === false) {
             continue

--- a/index.js
+++ b/index.js
@@ -53,12 +53,6 @@ module.exports = function (fastify, opts, next) {
               for (let index = 0; index < files.length; index++) {
                 const file = files[index]
 
-                // windows debugging
-                console.log(file)
-                console.log(toLoad)
-                console.log(toLoad.split(path.sep).pop())
-                // end windows debugging
-
                 plugins.push({
                   skip: !file.match(/.js$/),
                   opts: {

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(35)
+t.plan(47)
 
 const app = Fastify()
 
@@ -28,6 +28,42 @@ app.ready(function (err) {
 
     t.equal(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { answer: 42 })
+  })
+
+  app.inject({
+    url: '/autoroute/items/1'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { answer: 42 })
+  })
+
+  app.inject({
+    url: '/autoroute/items'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), [{ answer: 42 }, { answer: 41 }])
+  })
+
+  app.inject({
+    url: '/semiautomatic/items/1'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { answer: 42 })
+  })
+
+  app.inject({
+    url: '/semiautomatic/items'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), [{ answer: 42 }, { answer: 41 }])
   })
 
   app.inject({

--- a/test/basic/foo/autoroute/get.js
+++ b/test/basic/foo/autoroute/get.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/items/:id', (request, reply) => {
+    reply.send({ answer: 42 })
+  })
+
+  next()
+}

--- a/test/basic/foo/autoroute/list.js
+++ b/test/basic/foo/autoroute/list.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/items', (request, reply) => {
+    reply.send([{ answer: 42 }, { answer: 41 }])
+  })
+
+  next()
+}

--- a/test/basic/foo/manualprefix/get.js
+++ b/test/basic/foo/manualprefix/get.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/items/:id', (request, reply) => {
+    reply.send({ answer: 42 })
+  })
+
+  next()
+}

--- a/test/basic/foo/manualprefix/index.js
+++ b/test/basic/foo/manualprefix/index.js
@@ -1,0 +1,8 @@
+module.exports = function (fastify, opts, next) {
+  fastify.register(require('./list'))
+  fastify.register(require('./get'))
+
+  next()
+}
+
+module.exports.autoPrefix = '/semiautomatic'

--- a/test/basic/foo/manualprefix/list.js
+++ b/test/basic/foo/manualprefix/list.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/items', (request, reply) => {
+    reply.send([{ answer: 42 }, { answer: 41 }])
+  })
+
+  next()
+}

--- a/test/basic/foo/package/answer.js
+++ b/test/basic/foo/package/answer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = function (f, opts, next) {
-  f.get('/', (request, reply) => {
+  f.get('/package', (request, reply) => {
     reply.send({ answer: 42 })
   })
 

--- a/test/basic/foo/package/answer.js
+++ b/test/basic/foo/package/answer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = function (f, opts, next) {
-  f.get('/package', (request, reply) => {
+  f.get('/', (request, reply) => {
     reply.send({ answer: 42 })
   })
 


### PR DESCRIPTION
This feature allows building routes from files automatically and prefixes the routes with the folder name.

As an example, a typical API structure:

- /services/products/list.js
- /services/products/get.js

both files have similar code:

list:

```
module.exports = function(fastify, opts, next) {
  fastify.route({
    method: 'GET',
    url: '/',
    handler: function(request, reply) {
      reply.send({ hello: 'world' })
    }
  })
  next()
}
```

get:

```
module.exports = function(fastify, opts, next) {
  fastify.route({
    method: 'GET',
    url: '/:id',
    handler: function(request, reply) {
      reply.send({ hello: 'world' })
    }
  })
  next()
}
```

Without this feature, I'd need a separate index.js file with this content:

```
module.exports = function(fastify, opts, next) {
  fastify.register(require('./list'))
  fastify.register(require('./get'))
  next()
}
```

To load each module. With this patch, routes will automatically be loaded as `localhost:3000/products` and `localhost:3000/products/:id`

There are some complications with that approach, if `a.js` uses `/:id` and `b.js` uses `/something`, `/something` is not reachable because it's loaded after a.js. I'll address those in a separate issue.

Let me know what you think and if it's good to merge.