### PR TITLE
Automatically wrap full routes into fastify plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,24 @@ module.exports = function (f, opts, next) {
  */
 ```
 
+For routes (not plugins), you can skip the "boilerplate" of exporting the fastify function and use a route schema ([full route declaration](https://www.fastify.io/docs/master/Routes/#full-declaration)) instead. The method, url and handler are required, everything else optional. If you need additional options such as a `prefix` or `ignorePattern`, this does _not_ work.
+
+```js
+// /services/items/list.js
+module.exports = {
+  method: 'GET',
+  url: '/:id',
+  handler: (request, reply) => {
+    reply.send({ answer: 42 })
+  }
+}
+
+/**
+ * Routes generated:
+ * GET /items
+ */
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ For routes (not plugins), you can skip the "boilerplate" of exporting the fastif
 // /services/items/list.js
 module.exports = {
   method: 'GET',
-  url: '/:id',
+  url: '/',
   handler: (request, reply) => {
     reply.send({ answer: 42 })
   }

--- a/index.js
+++ b/index.js
@@ -107,7 +107,18 @@ module.exports = function (fastify, opts, next) {
         }
 
         try {
-          const plugin = require(file)
+          const content = require(file)
+          let plugin
+
+          if (content && typeof content === 'object' && content.method) {
+            plugin = function (fastify, opts, next) {
+              fastify.route(content)
+              next()
+            }
+          } else {
+            plugin = content
+          }
+
           const pluginOptions = Object.assign({}, defaultPluginOptions)
           const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
           const pluginName = pluginMeta.name || file

--- a/index.js
+++ b/index.js
@@ -109,8 +109,9 @@ module.exports = function (fastify, opts, next) {
         try {
           const content = require(file)
           let plugin
-
-          if (content && typeof content === 'object' && content.method) {
+          if (content && typeof content === 'object' &&
+          Object.prototype.toString.apply(content) === '[object Object]' &&
+          Object.prototype.hasOwnProperty.call(content, 'method')) {
             plugin = function (fastify, opts, next) {
               fastify.route(content)
               next()

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function (fastify, opts, next) {
         try {
           const content = require(file)
           let plugin
-          if (content && typeof content === 'object' &&
+          if (content &&
           Object.prototype.toString.apply(content) === '[object Object]' &&
           Object.prototype.hasOwnProperty.call(content, 'method')) {
             plugin = function (fastify, opts, next) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(47)
+t.plan(53)
 
 const app = Fastify()
 
@@ -41,6 +41,24 @@ app.ready(function (err) {
 
   app.inject({
     url: '/autoroute/items'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), [{ answer: 42 }, { answer: 41 }])
+  })
+
+  app.inject({
+    url: '/autowrap/1'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { answer: 42 })
+  })
+
+  app.inject({
+    url: '/autowrap'
   }, function (err, res) {
     t.error(err)
 

--- a/test/basic/foo/autowrap/get.js
+++ b/test/basic/foo/autowrap/get.js
@@ -1,0 +1,7 @@
+module.exports = {
+  method: 'GET',
+  url: '/:id',
+  handler: (request, reply) => {
+    reply.send({ answer: 42 })
+  }
+}

--- a/test/basic/foo/autowrap/list.js
+++ b/test/basic/foo/autowrap/list.js
@@ -1,0 +1,7 @@
+module.exports = {
+  method: 'GET',
+  url: '/',
+  handler: (request, reply) => {
+    reply.send([{ answer: 42 }, { answer: 41 }])
+  }
+}


### PR DESCRIPTION
Closes #54 

The idea is to reduce the routing files to just the route schema, without wrapping everything into a fastify plugin in every file. It's a cosmetic change.

I'm missing the docs part. Let me know if everything is good to go, then I'll add the part to the README.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
