### PR TITLE
support plugin.autoConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,20 @@ module.exports = function (fastify, opts, next) {
 module.exports.autoload = false
 ```
 
-Each plugin can also define it's own default options on a `options` property:
+Each plugin can also define it's own default base options on an `options` property:
+
+```js
+const fp = require('fastify-plugin')
+module.exports = fp(function (fastify, opts, next) {
+  console.log(opts.foo) // 'bar'
+  next()
+})
+
+// default base options
+module.exports.options = { foo: 'bar' }
+```
+
+To achieve the same without `fastify-plugin`:
 
 ```js
 module.exports = function (fastify, opts, next) {
@@ -64,9 +77,19 @@ module.exports = function (fastify, opts, next) {
   next()
 }
 
-// default options
-module.exports.options = { foo: 'bar' }
+// default base options
+module.exports[Symbol.for('base-options')] = { foo: 'bar' }
 ```
+
+The `plugin.options` property can also be used to configure required plugins: 
+
+```js
+const helmet = require('fastify-helmet')
+helmet.options = { referrerPolicy: true }
+module.exports = helmet
+```
+
+Note that each time a `plugin.options` property is consumed by fastify-autoload it will be reset back to the original base options (or else `undefined`).
 
 If you want to pass some custom options to all registered plugins via `fastify-autoload`, use the `options` key:
 
@@ -215,6 +238,7 @@ module.exports = {
  * GET /items
  */
 ```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,20 @@ module.exports = function (fastify, opts, next) {
 module.exports.autoload = false
 ```
 
-If you want to pass some custom options to the registered plugins via `fastify-autoload`, use the `options` key:
+Each plugin can also define it's own default options on a `options` property:
+
+```js
+module.exports = function (fastify, opts, next) {
+  console.log(opts.foo) // 'bar'
+  next()
+}
+
+// default options
+module.exports.options = { foo: 'bar' }
+```
+
+If you want to pass some custom options to all registered plugins via `fastify-autoload`, use the `options` key:
+
 ```js
 fastify.register(AutoLoad, {
   dir: path.join(__dirname, 'foo'),
@@ -64,6 +77,7 @@ fastify.register(AutoLoad, {
 })
 ```
 > *Note: `options` will be passed to all loaded plugins.*
+> *Note: global default options will override the `plugin.options` property*
 
 You can set the prefix option in the options passed to all plugins to set them all default prefix.
 When plugins get passed `prefix` as a default option, the `autoPrefix` property gets appended to them.

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = function (fastify, opts, next) {
             plugin = content
           }
 
-          const pluginOptions = Object.assign({}, defaultPluginOptions)
+          const pluginOptions = Object.assign({}, plugin.options || {}, defaultPluginOptions)
           const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
           const pluginName = pluginMeta.name || file
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const steed = require('steed')
-
+const kBaseOptions = Symbol.for('base-options')
 module.exports = function (fastify, opts, next) {
   const defaultPluginOptions = opts.options
 
@@ -119,10 +119,14 @@ module.exports = function (fastify, opts, next) {
           } else {
             plugin = content
           }
-
-          const pluginOptions = Object.assign({}, plugin.options || {}, defaultPluginOptions)
+          const pluginConfig = plugin.options || plugin[kBaseOptions] || {}
+          const pluginOptions = Object.assign({}, pluginConfig, defaultPluginOptions)
           const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
           const pluginName = pluginMeta.name || file
+
+          if (typeof plugin.options === 'object') {
+            plugin.options = plugin[kBaseOptions]
+          }
 
           if (opts && !plugin.autoPrefix) {
             plugin.autoPrefix = opts.prefix

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const steed = require('steed')
-const kBaseOptions = Symbol.for('base-options')
+
 module.exports = function (fastify, opts, next) {
   const defaultPluginOptions = opts.options
 
@@ -119,13 +119,13 @@ module.exports = function (fastify, opts, next) {
           } else {
             plugin = content
           }
-          const pluginConfig = plugin.options || plugin[kBaseOptions] || {}
+          const pluginConfig = plugin.autoConfig || {}
           const pluginOptions = Object.assign({}, pluginConfig, defaultPluginOptions)
           const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
           const pluginName = pluginMeta.name || file
 
-          if (typeof plugin.options === 'object') {
-            plugin.options = plugin[kBaseOptions]
+          if (typeof plugin.autoConfig === 'object') {
+            plugin.autoConfig = undefined
           }
 
           if (opts && !plugin.autoPrefix) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^1.12.0",
     "fastify": "^2.10.0",
-    "fastify-plugin": "^1.5.0",
+    "fastify-plugin": "https://github.com/davidmarkclements/fastify-plugin",
     "fastify-url-data": "^2.4.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^1.12.0",
     "fastify": "^2.10.0",
-    "fastify-plugin": "https://github.com/davidmarkclements/fastify-plugin",
+    "fastify-plugin": "^1.6.0",
     "fastify-url-data": "^2.4.0",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+
+t.plan(7)
+
+const app = Fastify()
+
+app.register(require('./options/app'))
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/plugin-a'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    // a is overriden by global option:
+    t.deepEqual(JSON.parse(res.payload), { data: 'test-1' })
+  })
+
+  app.inject({
+    url: '/plugin-b'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { data: 'override' })
+  })
+})

--- a/test/options.js
+++ b/test/options.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(7)
+t.plan(16)
 
 const app = Fastify()
 
@@ -27,5 +27,29 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { data: 'override' })
+  })
+
+  app.inject({
+    url: '/plugin-default'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { data: 'default' })
+  })
+
+  app.inject({
+    url: '/plugin-c'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { data: 'c' })
+  })
+
+  app.inject({
+    url: '/plugin-y'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { data: 'y' })
   })
 })

--- a/test/options/app.js
+++ b/test/options/app.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const path = require('path')
+const fastifyUrlData = require('fastify-url-data')
+
+const AutoLoad = require('../..')
+
+module.exports = function (fastify, opts, next) {
+  fastify.register(fastifyUrlData)
+
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    options: {
+      b: 'override'
+    }
+  })
+
+  next()
+}

--- a/test/options/app.js
+++ b/test/options/app.js
@@ -15,5 +15,13 @@ module.exports = function (fastify, opts, next) {
     }
   })
 
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'plugins-2')
+  })
+
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'plugins-3')
+  })
+
   next()
 }

--- a/test/options/lib-plugin.js
+++ b/test/options/lib-plugin.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+function plugin (f, opts, next) {
+  const { name } = opts
+  f.get('/plugin-' + name, (request, reply) => {
+    reply.send({ data: name })
+  })
+
+  next()
+}
+
+plugin.options = { name: 'default' }
+
+module.exports = fp(plugin, { name: 'lib-plugin' })

--- a/test/options/lib-plugin.js
+++ b/test/options/lib-plugin.js
@@ -3,14 +3,12 @@
 const fp = require('fastify-plugin')
 
 function plugin (f, opts, next) {
-  const { name } = opts
+  const { name = 'default' } = opts
   f.get('/plugin-' + name, (request, reply) => {
     reply.send({ data: name })
   })
 
   next()
 }
-
-plugin.options = { name: 'default' }
 
 module.exports = fp(plugin, { name: 'lib-plugin' })

--- a/test/options/plugins-2/plugin-x.js
+++ b/test/options/plugins-2/plugin-x.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const plugin = require('../lib-plugin')
+
+module.exports = plugin

--- a/test/options/plugins-3/plugin-y.js
+++ b/test/options/plugins-3/plugin-y.js
@@ -2,6 +2,6 @@
 
 const plugin = require('../lib-plugin')
 
-plugin.options = { name: 'y' }
+plugin.autoConfig = { name: 'y' }
 
 module.exports = plugin

--- a/test/options/plugins-3/plugin-y.js
+++ b/test/options/plugins-3/plugin-y.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const plugin = require('../lib-plugin')
+
+plugin.options = { name: 'y' }
+
+module.exports = plugin

--- a/test/options/plugins/plugin-a.js
+++ b/test/options/plugins/plugin-a.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+function plugin (f, opts, next) {
+  f.get('/plugin-a', (request, reply) => {
+    reply.send({ data: opts.a })
+  })
+
+  next()
+}
+
+plugin.options = { a: 'test-1' }
+
+module.exports = fp(plugin, { name: 'plugin-a' })

--- a/test/options/plugins/plugin-a.js
+++ b/test/options/plugins/plugin-a.js
@@ -10,6 +10,6 @@ function plugin (f, opts, next) {
   next()
 }
 
-plugin.options = { a: 'test-1' }
+plugin.autoConfig = { a: 'test-1' }
 
 module.exports = fp(plugin, { name: 'plugin-a' })

--- a/test/options/plugins/plugin-b.js
+++ b/test/options/plugins/plugin-b.js
@@ -10,6 +10,6 @@ function plugin (f, opts, next) {
   next()
 }
 
-plugin.options = { b: 'test-2' }
+plugin.autoConfig = { b: 'test-2' }
 
 module.exports = fp(plugin, { name: 'plugin-b' })

--- a/test/options/plugins/plugin-b.js
+++ b/test/options/plugins/plugin-b.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+function plugin (f, opts, next) {
+  f.get('/plugin-b', (request, reply) => {
+    reply.send({ data: opts.b })
+  })
+
+  next()
+}
+
+plugin.options = { b: 'test-2' }
+
+module.exports = fp(plugin, { name: 'plugin-b' })

--- a/test/options/plugins/plugin-c.js
+++ b/test/options/plugins/plugin-c.js
@@ -2,6 +2,6 @@
 
 const plugin = require('../lib-plugin')
 
-plugin.options = { name: 'c' }
+plugin.autoConfig = { name: 'c' }
 
 module.exports = plugin

--- a/test/options/plugins/plugin-c.js
+++ b/test/options/plugins/plugin-c.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const plugin = require('../lib-plugin')
+
+plugin.options = { name: 'c' }
+
+module.exports = plugin


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This allows plugins to declare their own default options, keys are overridden by custom options provided to autoload. Using the `options` namespace corresponds with `fastify-cli` `-o` flag functionality for the entry point plugin.

Beyond the declarative and convenience benefits this also supports a novel pattern where ecosystem plugins are configured in their own files - which for large scale applications may be easier to manage than in a single entry point. 

For instance consider the following: 

```js
const helmet = require('fastify-helmet')
helmet.options = { referrerPolicy: true }
module.exports = helmet
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
