### PR TITLE
Doesn't load the modules next to an index.js file (fix #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Autoload can be customised using the following options:
 
 - `dir` (required) - Base directory containing plugins to be loaded
 
-  Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In that case only the index file will be loaded.
+  Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In that case only the index file (and the potential sub-directories) will be loaded.
   
   The following script types are supported:
 

--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ async function findPlugins (dir, options, accumulator = [], prefix) {
     if (dirent.isDirectory()) {
       directoryPromises.push(findPlugins(file, options, accumulator, (prefix ? prefix + '/' : '') + dirent.name))
       continue
+    } else if (indexDirent) {
+      // An index.js file is present in the directory so we ignore the others modules (but not the subdirectories)
+      continue
     }
 
     if (dirent.isFile() && scriptPattern.test(dirent.name)) {

--- a/test/commonjs/basic.js
+++ b/test/commonjs/basic.js
@@ -191,7 +191,7 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 404)
   })
-  
+
   app.inject({
     url: '/one/'
   }, function (err, res) {

--- a/test/commonjs/basic.js
+++ b/test/commonjs/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(59)
+t.plan(61)
 
 const app = Fastify()
 
@@ -183,5 +183,12 @@ app.ready(function (err) {
 
     t.equal(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { works: true })
+  })
+
+  app.inject({
+    url: '/index/ignored'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 404)
   })
 })

--- a/test/commonjs/basic/index/ignored.js
+++ b/test/commonjs/basic/index/ignored.js
@@ -1,0 +1,7 @@
+// This module should be ignored because an index.js file is present in the same directory
+
+module.exports = async (server, opts, next) => {
+  server.get('/ignored', async (request, reply) => {
+    reply.status(200).send({ works: true })
+  })
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

--------------------------------------------
This PR assume that the desired behaviour for a directory containing an `index.js` file is to not load the files next to the `index.js` but load the modules in the potential sub-directories next to `index.js`:
```
routes
├── index.js // loaded
├── routeA.js // ignored
└── sub
    └── routeB.js // loaded
```