### PR TITLE
add snippet to allow loading multiple directories with one call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Folder structure:
 └── app.js
 ```
 
+**You can pass the options like as an array to load multiple instances.**
+
+```js
+...
+app.register(autoLoad, [
+  { dir: join(__dirname, 'plugins')},
+  { dir: join(__dirname, 'routes')},
+])
+....
+```
+
 ## Global Configuration
 
 Autoload can be customised using the following options:

--- a/README.md
+++ b/README.md
@@ -62,14 +62,22 @@ Folder structure:
 └── app.js
 ```
 
-**You can pass the options like as an array to load multiple instances.**
+**You can use arrays to load multiple instances, by you way.**
 
 ```js
 ...
+
+app.register(autoLoad, {
+  dir: [join(__dirname, 'plugins'), join(__dirname, 'routes')]
+})
+
+// or to don't share options inter directories:
+
 app.register(autoLoad, [
   { dir: join(__dirname, 'plugins')},
   { dir: join(__dirname, 'routes')},
 ])
+
 ....
 ```
 

--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -4,7 +4,7 @@
 import { FastifyPlugin, FastifyPluginOptions } from 'fastify'
 
 export interface AutoloadPluginOptions {
-  dir: string
+  dir: string | string []
   ignorePattern?: RegExp
   scriptPattern?: RegExp
   indexPattern?: RegExp

--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -11,6 +11,6 @@ export interface AutoloadPluginOptions {
   options?: FastifyPluginOptions
 }
 
-declare const fastifyAutoload: FastifyPlugin<AutoloadPluginOptions>
+declare const fastifyAutoload: FastifyPlugin<AutoloadPluginOptions | AutoloadPluginOptions[]>
 
 export default fastifyAutoload

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ const defaults = {
 }
 
 module.exports = async function fastifyAutoload (fastify, options) {
+  if (Array.isArray(options)) {
+    options.map(opts => {
+      fastifyAutoload(fastify, opts)
+    })
+
+    return
+  }
+
   const packageType = await getPackageType(options.dir)
   const opts = { ...defaults, packageType, ...options }
   const plugins = await findPlugins(opts.dir, opts)

--- a/index.js
+++ b/index.js
@@ -15,9 +15,17 @@ const defaults = {
 
 module.exports = async function fastifyAutoload (fastify, options) {
   if (Array.isArray(options)) {
-    options.map(opts => {
+    await Promise.all(options.map(opts =>
       fastifyAutoload(fastify, opts)
-    })
+    ))
+
+    return
+  }
+
+  if (Array.isArray(options.dir)) {
+    await Promise.all(options.dir.map(dir =>
+      fastifyAutoload(fastify, { ...options, dir })
+    ))
 
     return
   }

--- a/test/module/basic.js
+++ b/test/module/basic.js
@@ -2,7 +2,7 @@ import t from 'tap'
 import fastify from 'fastify'
 import basicApp from './basic/app.js'
 
-t.plan(53)
+t.plan(56)
 
 const app = fastify()
 
@@ -166,5 +166,13 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { no: 'prefix' })
+  })
+
+  app.inject({
+    url: '/dir'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { ecto: 'ries' })
   })
 })

--- a/test/module/basic/app.js
+++ b/test/module/basic/app.js
@@ -8,16 +8,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default function (fastify, opts, next) {
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'foo'),
-    options: { foo: 'bar' },
-    ignorePattern: /^ignored/
-  })
-
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'defaultPrefix'),
-    options: { prefix: '/defaultPrefix' }
-  })
+  fastify.register(autoLoad, [
+    {
+      dir: [
+        path.join(__dirname, 'foo'),
+        path.join(__dirname, 'dir')
+      ],
+      options: { foo: 'bar' },
+      ignorePattern: /^ignored/
+    },
+    {
+      dir: path.join(__dirname, 'defaultPrefix'),
+      options: { prefix: '/defaultPrefix' }
+    }
+  ])
 
   const skipDir = path.join(__dirname, 'skip')
   fs.mkdir(path.join(skipDir, 'empty'), () => {

--- a/test/module/basic/dir/directories.js
+++ b/test/module/basic/dir/directories.js
@@ -1,0 +1,7 @@
+export default function (f, opts, next) {
+  f.get('/dir', (request, reply) => {
+    reply.send({ ecto: 'ries' })
+  })
+
+  next()
+}


### PR DESCRIPTION
Like this:
```js
...
app.register(autoLoad, [
  { dir: join(__dirname, 'plugins')},
  { dir: join(__dirname, 'routes')},
])
....
```
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included // I think this don't need a test.
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
