### PR TITLE
Add maxDepth option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Autoload can be customised using the following options:
 - `dir` (required) - Base directory containing plugins to be loaded
 
   Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In that case only the index file (and the potential sub-directories) will be loaded.
-  
+
   The following script types are supported:
 
   - `.js ` (CommonJS or ES modules depending on `type` field of parent `package.json`)
@@ -104,7 +104,16 @@ Autoload can be customised using the following options:
     indexPattern: /.*routes(\.ts|\.js|\.cjs|\.mjs)$/
   })
   ```
-  
+
+- `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
+
+  ```js
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    maxDepth: 2 // files in `opts.dir` nested more than 2 directories deep will be ignored.
+  })
+  ```
+
 - `options` (optional) - Global options object used for all registered plugins
 
   Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
@@ -195,7 +204,7 @@ Each plugin can be individually configured using the following module properties
   export const autoPrefix = '/prefixed'
   ```
 
-  
+
 - `plugin.prefixOverride` - Override all other prefix option
 
   ```js
@@ -248,7 +257,7 @@ Each plugin can be individually configured using the following module properties
 - `plugin.autoload` - Toggle whether the plugin should be loaded
 
   Example:
-  
+
   ```js
   module.exports = function (fastify, opts, next) {
     // your plugin
@@ -276,7 +285,7 @@ Each plugin can be individually configured using the following module properties
     name: 'plugin-a',
     dependencies: ['plugin-b']
   })
-  
+
   // plugins/plugin-b.js
   function plugin (fastify, opts, next) {
     // plugin b

--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ function getScriptType (fname, packageType) {
   return (modulePattern.test(fname) ? 'module' : commonjsPattern.test(fname) ? 'commonjs' : typescriptPattern.test(fname) ? 'typescript' : packageType) || 'commonjs'
 }
 
-async function findPlugins (dir, options, accumulator = [], prefix) {
-  const { indexPattern, ignorePattern, scriptPattern, dirNameRoutePrefix = true } = options
+async function findPlugins (dir, options, accumulator = [], prefix, depth = 0) {
+  const { indexPattern, ignorePattern, scriptPattern, dirNameRoutePrefix = true, maxDepth } = options
   const list = await readdir(dir, { withFileTypes: true })
 
   // Contains index file?
@@ -86,9 +86,10 @@ async function findPlugins (dir, options, accumulator = [], prefix) {
       continue
     }
 
+    const atMaxDepth = Number.isFinite(maxDepth) && maxDepth <= depth
     const file = path.join(dir, dirent.name)
-    if (dirent.isDirectory()) {
-      directoryPromises.push(findPlugins(file, options, accumulator, (prefix ? prefix + '/' : '/') + (dirNameRoutePrefix ? dirent.name : '')))
+    if (dirent.isDirectory() && !atMaxDepth) {
+      directoryPromises.push(findPlugins(file, options, accumulator, (prefix ? prefix + '/' : '/') + (dirNameRoutePrefix ? dirent.name : ''), depth + 1))
       continue
     } else if (indexDirent) {
       // An index.js file is present in the directory so we ignore the others modules (but not the subdirectories)

--- a/test/module/basic.js
+++ b/test/module/basic.js
@@ -2,7 +2,7 @@ import t from 'tap'
 import fastify from 'fastify'
 import basicApp from './basic/app.js'
 
-t.plan(65)
+t.plan(74)
 
 const app = fastify()
 
@@ -198,5 +198,33 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.deepEqual(JSON.parse(res.payload), { works: true })
+  })
+
+  app.inject({
+    url: '/nested/shallow'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { works: true })
+  })
+
+  app.inject({
+    url: '/nested/shallow/deep'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { works: true })
+  })
+
+  app.inject({
+    url: '/nested/shallow/deep/deeper'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 404)
+    t.deepEqual(JSON.parse(res.payload), {
+      message: 'Route GET:/nested/shallow/deep/deeper not found',
+      error: 'Not Found',
+      statusCode: 404
+    })
   })
 })

--- a/test/module/basic/app.js
+++ b/test/module/basic/app.js
@@ -30,6 +30,12 @@ export default function (fastify, opts, next) {
     options: { prefix: 'ten/' }
   })
 
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'nested'),
+    maxDepth: 2,
+    options: { prefix: 'nested/' }
+  })
+
   const skipDir = path.join(__dirname, 'skip')
   fs.mkdir(path.join(skipDir, 'empty'), () => {
     fastify.register(autoLoad, {

--- a/test/module/basic/nested/shallow/deep/deeper/index.js
+++ b/test/module/basic/nested/shallow/deep/deeper/index.js
@@ -1,0 +1,5 @@
+export default async (server, opts) => {
+  server.get('/', async (req, reply) => {
+    reply.send({ works: true })
+  })
+}

--- a/test/module/basic/nested/shallow/deep/index.js
+++ b/test/module/basic/nested/shallow/deep/index.js
@@ -1,0 +1,5 @@
+export default async (server, opts) => {
+  server.get('/', async (req, reply) => {
+    reply.send({ works: true })
+  })
+}

--- a/test/module/basic/nested/shallow/index.js
+++ b/test/module/basic/nested/shallow/index.js
@@ -1,0 +1,5 @@
+export default async (server, opts) => {
+  server.get('/', async (req, reply) => {
+    reply.send({ works: true })
+  })
+}


### PR DESCRIPTION
### Summary
Relates to #89. However, instead of toggling recursion this provides the ability to set the maximum depth of nesting that plugins will be loaded at. 

Setting `maxDepth: 1` would be the equivalent of `recursive: false`, and setting `maxDepth: 0` would allow for a flattened directory structure like so:
```
plugins/
|__  pluginOne.js
|__  pluginTwo.js
|__  lib/
     |__  utilOne.js
     |__  utilTwo.js
```

### Test plan
Confirm the added unit tests pass.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
