### PR TITLE
fix: fixed error when importing using esm syntax

### DIFF
--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -18,3 +18,4 @@ declare const fastifyAutoload: FastifyPlugin<AutoloadPluginOptions>
 type RewritePrefix = (folderParent: string, folderName: string) => string | boolean
 
 export default fastifyAutoload
+export { fastifyAutoload }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaults = {
   dirNameRoutePrefix: true
 }
 
-module.exports = async function fastifyAutoload (fastify, options) {
+const autoload = async function fastifyAutoload (fastify, options) {
   const packageType = await getPackageType(options.dir)
   const opts = { ...defaults, packageType, ...options }
   const plugins = await findPlugins(opts.dir, opts)
@@ -208,6 +208,9 @@ function enrichError (err) {
   }
   return err
 }
+
+module.exports = autoload
+module.exports.default = autoload
 
 // do not create a new context, do not encapsulate
 // same as fastify-plugin

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaults = {
   dirNameRoutePrefix: true
 }
 
-const autoload = async function fastifyAutoload (fastify, options) {
+const fastifyAutoload = async function autoload (fastify, options) {
   const packageType = await getPackageType(options.dir)
   const opts = { ...defaults, packageType, ...options }
   const plugins = await findPlugins(opts.dir, opts)
@@ -209,8 +209,9 @@ function enrichError (err) {
   return err
 }
 
-module.exports = autoload
-module.exports.default = autoload
+fastifyAutoload.fastifyAutoload = fastifyAutoload
+fastifyAutoload.default = fastifyAutoload
+module.exports = fastifyAutoload
 
 // do not create a new context, do not encapsulate
 // same as fastify-plugin

--- a/index.js
+++ b/index.js
@@ -209,10 +209,10 @@ function enrichError (err) {
   return err
 }
 
-fastifyAutoload.fastifyAutoload = fastifyAutoload
-fastifyAutoload.default = fastifyAutoload
-module.exports = fastifyAutoload
-
 // do not create a new context, do not encapsulate
 // same as fastify-plugin
 module.exports[Symbol.for('skip-override')] = true
+
+module.exports = fastifyAutoload
+module.exports.fastifyAutoload = fastifyAutoload
+module.exports.default = fastifyAutoload

--- a/test/module/esm-import.js
+++ b/test/module/esm-import.js
@@ -1,0 +1,48 @@
+import t from 'tap'
+import fastify from 'fastify'
+import esmImportApp from './esm-import/app.js'
+
+t.plan(13)
+
+const app = fastify()
+
+app.register(esmImportApp)
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/named'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { script: 'named' })
+  })
+
+  app.inject({
+    url: '/default'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { script: 'default' })
+  })
+
+  app.inject({
+    url: '/star-default'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { script: 'star-default' })
+  })
+  app.inject({
+    url: '/star-named'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { script: 'star-named' })
+  })
+})

--- a/test/module/esm-import/app.js
+++ b/test/module/esm-import/app.js
@@ -1,0 +1,31 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+import { fastifyAutoload as fastifyAutoloadNamed } from "../../../index.js"
+import fastifyAutoloadDefault from '../../../index.js'
+import * as fastifyAutoloadStar from '../../../index.js'
+
+export default async function (fastify, opts) {
+  fastify.register(fastifyAutoloadNamed, {
+    dir: path.join(__dirname, 'plugins', 'named'),
+    options: { foo: 'bar' }
+  })
+
+  fastify.register(fastifyAutoloadDefault, {
+    dir: path.join(__dirname, 'plugins', 'default'),
+    options: { foo: 'bar' }
+  })
+
+  fastify.register(fastifyAutoloadStar.default, {
+    dir: path.join(__dirname, 'plugins', 'star-default'),
+    options: { foo: 'bar' }
+  })
+  fastify.register(fastifyAutoloadStar.fastifyAutoload, {
+    dir: path.join(__dirname, 'plugins', 'star-named'),
+    options: { foo: 'bar' }
+  })
+}

--- a/test/module/esm-import/plugins/default/index.js
+++ b/test/module/esm-import/plugins/default/index.js
@@ -1,0 +1,5 @@
+export default async function (fastify, opts) {
+  fastify.get('/default', async (request, reply) => {
+    return { script: 'default' }
+  })
+}

--- a/test/module/esm-import/plugins/named/index.js
+++ b/test/module/esm-import/plugins/named/index.js
@@ -1,0 +1,5 @@
+export default async function (fastify, opts) {
+  fastify.get('/named', async (request, reply) => {
+    return { script: 'named' }
+  })
+}

--- a/test/module/esm-import/plugins/star-default/index.js
+++ b/test/module/esm-import/plugins/star-default/index.js
@@ -1,0 +1,5 @@
+export default async function (fastify, opts) {
+  fastify.get('/star-default', async (request, reply) => {
+    return { script: 'star-default' }
+  })
+}

--- a/test/module/esm-import/plugins/star-named/index.js
+++ b/test/module/esm-import/plugins/star-named/index.js
@@ -1,0 +1,5 @@
+export default async function (fastify, opts) {
+  fastify.get('/star-named', async (request, reply) => {
+    return { script: 'star-named' }
+  })
+}

--- a/test/typescript/basic/app.ts
+++ b/test/typescript/basic/app.ts
@@ -1,6 +1,6 @@
 import { FastifyPlugin } from 'fastify'
 import { join } from 'path'
-const fastifyAutoLoad = require('../../../')
+import fastifyAutoLoad from '../../../'
 
 const app: FastifyPlugin = function (fastify, opts, next): void {
   fastify.register(fastifyAutoLoad, {

--- a/test/typescript/definitions/fastify-autoload.test-d.ts
+++ b/test/typescript/definitions/fastify-autoload.test-d.ts
@@ -1,7 +1,33 @@
-import autoload, { AutoloadPluginOptions } from '../../../'
-import fastify from 'fastify'
+import fastify, { FastifyInstance, FastifyPlugin } from 'fastify'
+import { expectType } from 'tsd'
 
-const app = fastify()
+import { fastifyAutoload as fastifyAutoloadNamed, AutoloadPluginOptions } from "../../../"
+import fastifyAutoloadDefault from "../../../"
+import * as fastifyAutoloadStar from "../../../"
+import fastifyAutoloadCjsImport = require("../../../")
+const fastifyAutoloadCjs = require("../../../")
+
+const app: FastifyInstance = fastify();
+app.register(fastifyAutoloadNamed);
+app.register(fastifyAutoloadDefault);
+app.register(fastifyAutoloadCjs);
+app.register(fastifyAutoloadCjsImport.default);
+app.register(fastifyAutoloadCjsImport.fastifyAutoload);
+app.register(fastifyAutoloadStar.default);
+app.register(fastifyAutoloadStar.fastifyAutoload);
+
+expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadNamed);
+expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadDefault);
+expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadCjsImport.default);
+expectType<FastifyPlugin<AutoloadPluginOptions>>(
+  fastifyAutoloadCjsImport.fastifyAutoload
+);
+expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadStar.default);
+expectType<FastifyPlugin<AutoloadPluginOptions>>(
+  fastifyAutoloadStar.fastifyAutoload
+);
+expectType<any>(fastifyAutoloadCjs);
+
 let opt1: AutoloadPluginOptions = {
   dir: 'test'
 }
@@ -24,8 +50,8 @@ const opt5: AutoloadPluginOptions = {
   dir: 'test',
   maxDepth: 1,
 }
-app.register(autoload, opt1)
-app.register(autoload, opt2)
-app.register(autoload, opt3)
-app.register(autoload, opt4)
-app.register(autoload, opt5)
+app.register(fastifyAutoloadDefault, opt1)
+app.register(fastifyAutoloadDefault, opt2)
+app.register(fastifyAutoloadDefault, opt3)
+app.register(fastifyAutoloadDefault, opt4)
+app.register(fastifyAutoloadDefault, opt5)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

When importing autoload using `import autoload from 'fastify-autoload'` I get an error which `Error: plugin must be a function or a promise`.
Using commonjs syntax works fine but I believe we want to make it work in both scenarios.

I changed the unit test which was using `require` to include autoload.

PS
I also believe this might be the fix needed [here](https://github.com/fastify/fastify-cli/issues/303) too.