### PR TITLE
feat: route parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,31 @@ Autoload can be customised using the following options:
   })
   ```
 
+- `routeParams` (optional) - Folders prefixed with `_` will be turned into route parameters.
+
+  ```js
+  /*
+  ├── routes
+  │   └── users
+  │       ├── _id
+  │       │   └── actions.js
+  │       └── index.js
+  └── app.js
+  */
+
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    routeParams: true // routes/users/_id/actions.js will be loaded with prefix /users/:id
+  })  
+
+  // curl http://localhost:3000/users/index
+  // { userIndex: [ { id: 7, username: 'example' } ] }
+
+  // curl http://localhost:3000/users/7/details
+  // { user: { id: 7, username: 'example' } }
+
+  ```
+
 ## Plugin Configuration
 
 Each plugin can be individually configured using the following module properties:

--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ const hasTsJest = 'npm_package_devDependencies_ts_jest' in process.env
 const typescriptSupport = isTsNode || (isJestEnviroment && hasTsJest)
 
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
+const routeParamPattern = /\/_/i
 
 const defaults = {
   scriptPattern: /((^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
   indexPattern: /^index(\.ts|\.js|\.cjs|\.mjs)$/i,
   autoHooksPattern: /^[_.]?auto_?hooks(\.ts|\.js|\.cjs|\.mjs)$/i,
-  routeParamPattern: /\/_/i,
   dirNameRoutePrefix: true
 }
 
@@ -36,7 +36,7 @@ const fastifyAutoload = async function autoload (fastify, options) {
       .then((plugin) => {
         if (plugin) {
           // create route parameters from prefixed folders
-          if (options.routeParams) plugin.options.prefix = plugin.options.prefix ? plugin.options.prefix.replace(opts.routeParamPattern, '/:') : plugin.options.prefix
+          if (options.routeParams) plugin.options.prefix = plugin.options.prefix ? plugin.options.prefix.replace(routeParamPattern, '/:') : plugin.options.prefix
           pluginsMeta[plugin.name] = plugin
         }
       })

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const defaults = {
   scriptPattern: /((^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
   indexPattern: /^index(\.ts|\.js|\.cjs|\.mjs)$/i,
   autoHooksPattern: /^[_.]?auto_?hooks(\.ts|\.js|\.cjs|\.mjs)$/i,
+  routeParamPattern: /\/_/i,
   dirNameRoutePrefix: true
 }
 
@@ -34,6 +35,8 @@ const fastifyAutoload = async function autoload (fastify, options) {
     return loadPlugin(file, type, prefix, opts)
       .then((plugin) => {
         if (plugin) {
+          // create route parameters from prefixed folders
+          if (options.routeParams) plugin.options.prefix = plugin.options.prefix ? plugin.options.prefix.replace(opts.routeParamPattern, '/:') : plugin.options.prefix
           pluginsMeta[plugin.name] = plugin
         }
       })
@@ -41,7 +44,6 @@ const fastifyAutoload = async function autoload (fastify, options) {
         throw enrichError(err)
       })
   }))
-
   await Promise.all(hookArray.map((h) => {
     if (hooksMeta[h.file]) return null // hook plugin already loaded, skip this instance
     return loadHook(h)

--- a/test/commonjs/route-parameters-basic.js
+++ b/test/commonjs/route-parameters-basic.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+
+t.plan(10)
+
+const app = Fastify()
+
+app.register(require('./route-parameters/basic'))
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/users'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { users: [{ id: 7, username: 'example' }] })
+  })
+
+  app.inject({
+    url: '/users/7'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { user: { id: 7, username: 'example' } })
+  })
+
+  app.inject({
+    url: '/users/_id'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { user: { id: '_id', username: 'example' } })
+  })
+})

--- a/test/commonjs/route-parameters-disabled.js
+++ b/test/commonjs/route-parameters-disabled.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+
+t.plan(9)
+
+const app = Fastify()
+
+app.register(require('./route-parameters/disabled'))
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/users'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { users: [{ id: 7, username: 'example' }] })
+  })
+
+  app.inject({
+    url: '/users/7'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 404)
+  })
+
+  app.inject({
+    url: '/users/_id'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.payload), { user: { id: 'null', username: 'example' } })
+  })
+})

--- a/test/commonjs/route-parameters/basic.js
+++ b/test/commonjs/route-parameters/basic.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const path = require('path')
+const autoLoad = require('../../../')
+
+module.exports = function (fastify, opts, next) {
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    routeParams: true
+  })
+
+  next()
+}

--- a/test/commonjs/route-parameters/disabled.js
+++ b/test/commonjs/route-parameters/disabled.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const path = require('path')
+const autoLoad = require('../../../')
+
+module.exports = function (fastify, opts, next) {
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    routeParams: false
+  })
+
+  next()
+}

--- a/test/commonjs/route-parameters/routes/users/_id/actions.js
+++ b/test/commonjs/route-parameters/routes/users/_id/actions.js
@@ -1,0 +1,5 @@
+module.exports = async function (app, opts, next) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ user: { id: req.params.id || 'null', username: 'example' } }) // explicit null reply to preserve response body
+  })
+}

--- a/test/commonjs/route-parameters/routes/users/index.js
+++ b/test/commonjs/route-parameters/routes/users/index.js
@@ -1,0 +1,5 @@
+module.exports = async function (app, opts, next) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ users: [{ id: 7, username: 'example' }] })
+  })
+}

--- a/test/module/route-parameters.js
+++ b/test/module/route-parameters.js
@@ -32,6 +32,10 @@ test('routeParams: Default behaviour', async () => {
   res = await app.inject('/pages/test_id/edit')
   t.equal(res.statusCode, 200)
   t.deepEqual(res.json(), { route: '/pages/:id/edit', id: 'test_id' })
+
+  res = await app.inject('/users/test_id/details')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/users/:id/details', id: 'test_id' })
 })
 
 test('routeParams: off', async () => {
@@ -67,4 +71,11 @@ test('routeParams: off', async () => {
   res = await app.inject('/pages/_id/edit')
   t.equal(res.statusCode, 200)
   t.deepEqual(res.json(), { route: '/pages/:id/edit' })
+
+  res = await app.inject('/users/test_id/details')
+  t.equal(res.statusCode, 404)
+
+  res = await app.inject('/users/_id/details')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/users/:id/details' })
 })

--- a/test/module/route-parameters.js
+++ b/test/module/route-parameters.js
@@ -1,0 +1,70 @@
+import t from 'tap'
+import fastify from 'fastify'
+import routeParametersBasic from './route-parameters/basic.mjs'
+import routeParametersDisabled from './route-parameters/disabled.mjs'
+
+const { test } = t
+
+test('routeParams: Default behaviour', async () => {
+  const app = fastify()
+  let res
+
+  app.register(routeParametersBasic)
+
+  await app.ready()
+
+  res = await app.inject('/')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/' })
+
+  res = await app.inject('/pages')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages' })
+
+  res = await app.inject('/pages/archived')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/archived' })
+
+  res = await app.inject('/pages/test_id')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/:id/', id: 'test_id' })
+
+  res = await app.inject('/pages/test_id/edit')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/:id/edit', id: 'test_id' })
+})
+
+test('routeParams: off', async () => {
+  const app = fastify()
+  let res
+
+  app.register(routeParametersDisabled)
+
+  await app.ready()
+
+  res = await app.inject('/')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/' })
+
+  res = await app.inject('/pages')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages' })
+
+  res = await app.inject('/pages/archived')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/archived' })
+
+  res = await app.inject('/pages/test_id')
+  t.equal(res.statusCode, 404)
+
+  res = await app.inject('/pages/test_id/edit')
+  t.equal(res.statusCode, 404)
+
+  res = await app.inject('/pages/_id')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/:id/' })
+
+  res = await app.inject('/pages/_id/edit')
+  t.equal(res.statusCode, 200)
+  t.deepEqual(res.json(), { route: '/pages/:id/edit' })
+})

--- a/test/module/route-parameters/basic.mjs
+++ b/test/module/route-parameters/basic.mjs
@@ -1,0 +1,15 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import autoload from '../../../index.js'
+
+const { dirname } = path
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export default async function (fastify, opts) {
+  fastify.register(autoload, {
+    dir: path.join(__dirname, 'routes'),
+    routeParams: true
+  })
+}

--- a/test/module/route-parameters/disabled.mjs
+++ b/test/module/route-parameters/disabled.mjs
@@ -1,0 +1,15 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import autoload from '../../../index.js'
+
+const { dirname } = path
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export default async function (fastify, opts) {
+  fastify.register(autoload, {
+    dir: path.join(__dirname, 'routes'),
+    routeParams: false
+  })
+}

--- a/test/module/route-parameters/routes/index.mjs
+++ b/test/module/route-parameters/routes/index.mjs
@@ -1,0 +1,5 @@
+export default async function (app, opts) {
+  app.get('/', async function (req, reply) {
+    return { route: '/' }
+  })
+}

--- a/test/module/route-parameters/routes/pages/_id/actions.mjs
+++ b/test/module/route-parameters/routes/pages/_id/actions.mjs
@@ -1,0 +1,9 @@
+export default async function (app, opts) {
+  app.get('/', async function (req, reply) {
+    return { route: '/pages/:id/', id: req.params.id }
+  })
+
+  app.get('/edit', async function (req, reply) {
+    return { route: '/pages/:id/edit', id: req.params.id }
+  })
+}

--- a/test/module/route-parameters/routes/pages/routes.mjs
+++ b/test/module/route-parameters/routes/pages/routes.mjs
@@ -1,0 +1,9 @@
+export default async function (app, opts) {
+  app.get('/', async function (req, reply) {
+    return { route: '/pages' }
+  })
+
+  app.get('/archived', async function (req, reply) {
+    return { route: '/pages/archived', id: req.params.id } // should be null
+  })
+}

--- a/test/module/route-parameters/routes/users/_id/actions.mjs
+++ b/test/module/route-parameters/routes/users/_id/actions.mjs
@@ -1,0 +1,5 @@
+export default async function (app, opts) {
+  app.get('/details', async function (req, reply) {
+    return { route: '/users/:id/details', id: req.params.id }
+  })
+}


### PR DESCRIPTION
Adds route parameters based on underscore-prefixed folders. See #133 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
