### PR TITLE
Fix decorator support when not using autoHooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ Autoload can be customised using the following options:
   })
   ```
 
+  If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/master/docs/Encapsulation.md)
+  and decorated values _will not be exported_ outside the folder.
+
 - `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
 
   ```js

--- a/index.js
+++ b/index.js
@@ -55,25 +55,33 @@ const fastifyAutoload = async function autoload (fastify, options) {
       })
   }))
 
+  const metas = Object.values(pluginsMeta)
   for (const prefix in pluginTree) {
     const hookFiles = pluginTree[prefix].hooks
     const pluginFiles = pluginTree[prefix].plugins
-    const composedPlugin = async function (app, opts) {
-      // find hook functions for this prefix
-      for (const hookFile of hookFiles) {
-        const hookPlugin = hooksMeta[hookFile.file]
-        // encapsulate hooks at plugin level
-        if (hookPlugin) app.register(hookPlugin)
+    if (hookFiles.length === 0) {
+      registerAllPlugins(fastify, pluginFiles)
+    } else {
+      const composedPlugin = async function (app) {
+        // find hook functions for this prefix
+        for (const hookFile of hookFiles) {
+          const hookPlugin = hooksMeta[hookFile.file]
+          // encapsulate hooks at plugin level
+          if (hookPlugin) app.register(hookPlugin)
+        }
+        registerAllPlugins(app, pluginFiles)
       }
-
-      for (const pluginFile of pluginFiles) {
-        // find plugins for this prefix, based on filename stored in registerPlugins()
-        const plugin = Object.values(pluginsMeta).find((i) => i.filename === pluginFile.file)
-        // register plugins at fastify level
-        if (plugin) registerPlugin(fastify, plugin, pluginsMeta)
-      }
+      fastify.register(composedPlugin)
     }
-    fastify.register(composedPlugin)
+  }
+
+  function registerAllPlugins (app, pluginFiles) {
+    for (const pluginFile of pluginFiles) {
+      // find plugins for this prefix, based on filename stored in registerPlugins()
+      const plugin = metas.find((i) => i.filename === pluginFile.file)
+      // register plugins at fastify level
+      if (plugin) registerPlugin(app, plugin, pluginsMeta)
+    }
   }
 }
 

--- a/test/commonjs/basic.js
+++ b/test/commonjs/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(85)
+t.plan(86)
 
 const app = Fastify()
 
@@ -11,6 +11,8 @@ app.register(require('./basic/app'))
 
 app.ready(function (err) {
   t.error(err)
+
+  t.is(app.foo, 'bar')
 
   app.inject({
     url: '/something'

--- a/test/commonjs/basic/app.js
+++ b/test/commonjs/basic/app.js
@@ -59,3 +59,5 @@ module.exports = function (fastify, opts, next) {
     next()
   })
 }
+
+module.exports[Symbol.for('skip-override')] = true

--- a/test/commonjs/basic/foo/decorator.js
+++ b/test/commonjs/basic/foo/decorator.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.decorate('foo', 'bar')
+
+  next()
+}
+
+module.exports[Symbol.for('skip-override')] = true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR address a severe regression in v3.5.0: decorated values will not be accessible outside of the autoload context, breaking our default template in fastify-cli.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
