### PR TITLE
feat: Added forceESM option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Autoload can be customised using the following options:
   })
   ```
 
+- `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
+
+  ```js
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    forceESM: true
+  })
+  ```
+
 - `options` (optional) - Global options object used for all registered plugins
 
   Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.

--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -11,6 +11,7 @@ export interface AutoloadPluginOptions {
   indexPattern?: RegExp
   options?: FastifyPluginOptions
   maxDepth?: number
+  forceESM?: boolean
   autoHooks?: boolean
   autoHooksPattern?: RegExp
   cascadeHooks?: boolean

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const fastifyAutoload = async function autoload (fastify, options) {
 
   await Promise.all(hookArray.map((h) => {
     if (hooksMeta[h.file]) return null // hook plugin already loaded, skip this instance
-    return loadHook(h)
+    return loadHook(h, opts)
       .then((hookPlugin) => {
         if (hookPlugin) {
           hooksMeta[h.file] = hookPlugin
@@ -214,9 +214,9 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 }
 
 async function loadPlugin (file, type, directoryPrefix, options) {
-  const { options: overrideConfig } = options
+  const { options: overrideConfig, forceESM } = options
   let content
-  if (type === 'module') {
+  if (forceESM || type === 'module') {
     content = await import(url.pathToFileURL(file).href)
   } else {
     content = require(file)
@@ -291,10 +291,10 @@ function wrapRoutes (content) {
   return content
 }
 
-async function loadHook (hook) {
+async function loadHook (hook, options) {
   if (!hook) return null
   let hookContent
-  if (hook.type === 'module') {
+  if (options.forceESM || hook.type === 'module') {
     hookContent = await import(url.pathToFileURL(hook.file).href)
   } else {
     hookContent = require(hook.file)

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "types": "fastify-autoload.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm",
     "typescript": "tsd",
     "typescript:jest": "jest",
+    "typescript:esm": "node scripts/unit-typescript-esm.js",
     "unit": "node scripts/unit.js",
-    "unit:with-modules": "tap test/*/*.js test/*/*.ts",
-    "unit:without-modules": "tap test/commonjs/*.js test/*/*.ts"
+    "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
+    "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/unit-typescript-esm.js
+++ b/scripts/unit-typescript-esm.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { exec } = require('child_process')
+const semver = require('semver')
+
+if (semver.satisfies(process.version, '>= 14 || >= 13.4.0 || >= 12.16.0 < 13.0.0')) {
+  const args = [
+    'tap',
+    '--node-arg=--loader=ts-node/esm',
+    '--node-arg=--experimental-specifier-resolution=node',
+    '--no-coverage',
+    'test/typescript-esm/*.ts'
+  ]
+
+  const child = exec(args.join(' '), {
+    shell: true,
+    env: {
+      ...process.env,
+      TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+        module: 'ESNext',
+        target: 'ES2020',
+        allowJs: false,
+        moduleResolution: 'node',
+        esModuleInterop: true
+      })
+    }
+  })
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  child.once('close', process.exit)
+}

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -9,3 +9,4 @@ const child = exec(semver.satisfies('>=14 || >= 12.17.0 < 13.0.0')
 
 child.stdout.pipe(process.stdout)
 child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/test/typescript-esm/app/index.ts
+++ b/test/typescript-esm/app/index.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+
+export default function (fastify: FastifyInstance, _: object, next): void {
+  fastify.get('/installed', (_: FastifyRequest, reply: FastifyReply): void => {
+    reply.send({ result: 'ok' })
+  })
+
+  next()
+}

--- a/test/typescript-esm/forceESM.ts
+++ b/test/typescript-esm/forceESM.ts
@@ -1,7 +1,7 @@
 import fastify from 'fastify'
-import { dirname, resolve } from 'path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import t from 'tap'
-import { fileURLToPath } from 'url'
 import fastifyAutoLoad from '../../'
 
 t.plan(4)

--- a/test/typescript-esm/forceESM.ts
+++ b/test/typescript-esm/forceESM.ts
@@ -1,0 +1,27 @@
+import fastify from 'fastify'
+import { dirname, resolve } from 'path'
+import t from 'tap'
+import { fileURLToPath } from 'url'
+import fastifyAutoLoad from '../../'
+
+t.plan(4)
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const app = fastify()
+
+app.register(fastifyAutoLoad, { dir: resolve(__dirname, 'app'), forceESM: true })
+
+app.ready(function (err): void {
+  t.error(err)
+
+  app.inject(
+    {
+      url: '/installed'
+    },
+    function (err, res): void {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      t.deepEqual(JSON.parse(res.payload), { result: 'ok' })
+    }
+  )
+})

--- a/test/typescript-esm/package.json
+++ b/test/typescript-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/typescript/definitions/fastify-autoload.test-d.ts
+++ b/test/typescript/definitions/fastify-autoload.test-d.ts
@@ -1,9 +1,8 @@
 import fastify, { FastifyInstance, FastifyPlugin } from 'fastify'
 import { expectType } from 'tsd'
-
-import { fastifyAutoload as fastifyAutoloadNamed, AutoloadPluginOptions } from "../../../"
-import fastifyAutoloadDefault from "../../../"
 import * as fastifyAutoloadStar from "../../../"
+import fastifyAutoloadDefault, { AutoloadPluginOptions, fastifyAutoload as fastifyAutoloadNamed } from "../../../"
+
 import fastifyAutoloadCjsImport = require("../../../")
 const fastifyAutoloadCjs = require("../../../")
 
@@ -52,6 +51,7 @@ const opt5: AutoloadPluginOptions = {
 }
 const opt6: AutoloadPluginOptions = {
   dir: 'test',
+  forceESM: true,
   autoHooks: true,
   autoHooksPattern: /^[_.]?auto_?hooks(\.js|\.cjs|\.mjs)$/i,
   cascadeHooks: true,


### PR DESCRIPTION
This PR adds the `forceESM` option, which always uses `await import` to load modules despite of the detected package type.

I run into this when running code via `ts-node` in a folder where `package.json` had `type='module'`.

I also tried to add a test for this, but I was not able to reproduce the problem in this repo, since `type!='module'`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
