### PR TITLE
Bump `ts-node` & `tsd`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.8",
     "@types/node": "^16.0.0",
+    "@types/tap": "^15.0.5",
     "fastify": "^3.0.0",
     "fastify-plugin": "^3.0.0",
     "fastify-url-data": "^3.0.3",
@@ -47,7 +48,7 @@
     "standard": "^16.0.1",
     "tap": "^15.0.0",
     "ts-jest": "^27.0.0",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.1.0",
     "ts-node-dev": "^1.1.1",
     "tsd": "^0.17.0",
     "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ts-jest": "^27.0.0",
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.1",
-    "tsd": "^0.16.0",
+    "tsd": "^0.17.0",
     "typescript": "^4.2.3"
   },
   "dependencies": {

--- a/test/typescript-esm/app/index.ts
+++ b/test/typescript-esm/app/index.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 
-export default function (fastify: FastifyInstance, _: object, next): void {
+export default function (fastify: FastifyInstance, _: object, next: (err?: Error) => void): void {
   fastify.get('/installed', (_: FastifyRequest, reply: FastifyReply): void => {
     reply.send({ result: 'ok' })
   })

--- a/test/typescript/basic.ts
+++ b/test/typescript/basic.ts
@@ -1,4 +1,4 @@
-import * as t from 'tap'
+import t from 'tap'
 import fastify from 'fastify'
 
 import basicApp from './basic/app'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description

Closes #173 

This PR bumps `tsd` to version `0.17` weirdly enough the update did not cause anything to break and instead the bot's PR failed because of a problem on npm as detailed on the CI error logs, `ts-node` has been updated to version `10.1.0` and a `@types/tap` was installed as a new devDependency, this was required as typescript refused to compile without tap's type definition files.




