### PR TITLE
Add SWC support

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,8 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    },
+    "target": "es2016"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -7,8 +7,10 @@ const pkgUp = require('pkg-up')
 const semver = require('semver')
 
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
-const isJestEnviroment = process.env.JEST_WORKER_ID !== undefined
-const typescriptSupport = isTsNode || isJestEnviroment
+const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
+const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
+const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
+const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNode
 
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 const routeParamPattern = /\/_/ig

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
+    "typescript:swc": "node scripts/unit-typescript-swc.js",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
     "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
@@ -36,6 +37,8 @@
   },
   "homepage": "https://github.com/fastify/fastify-autoload#readme",
   "devDependencies": {
+    "@swc/core": "^1.2.85",
+    "@swc/register": "^0.1.7",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.0.0",
     "@types/tap": "^15.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "fastify-autoload.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",

--- a/scripts/unit-typescript-swc.js
+++ b/scripts/unit-typescript-swc.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { exec } = require('child_process')
+const semver = require('semver')
+
+if (semver.satisfies(process.version, '>= 14')) {
+  const args = [
+    'tap',
+    '--node-arg=--require=@swc/register',
+    '--no-coverage',
+    'test/typescript/*.ts'
+  ]
+
+  const child = exec(args.join(' '), {
+    shell: true
+  })
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  child.once('close', process.exit)
+}


### PR DESCRIPTION
### What I did

- Add `@swc/core` transpiler support so that the consumer project can run typescript via `@swc/register` require hook.
- Related to #190.

Please let me know if the PR is okay, not sure the benchmark things though.

---

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)