### PR TITLE
Add tsm support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!proce
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
-const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNode
-
+const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
+const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNode || isTsm
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 const routeParamPattern = /\/_/ig
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "types": "fastify-autoload.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:tsm",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
     "typescript:swc": "node scripts/unit-typescript-swc.js",
+    "typescript:tsm": "node scripts/unit-typescript-tsm.js",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
     "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
@@ -54,6 +55,7 @@
     "ts-node": "^10.1.0",
     "ts-node-dev": "^1.1.1",
     "tsd": "^0.19.0",
+    "tsm": "^2.2.1",
     "typescript": "^4.2.3"
   },
   "dependencies": {

--- a/scripts/unit-typescript-tsm.js
+++ b/scripts/unit-typescript-tsm.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { exec } = require('child_process')
+const semver = require('semver')
+
+if (semver.satisfies(process.version, '>= 14')) {
+  const args = [
+    'tap',
+    '--no-ts',
+    '--node-arg=--require=tsm',
+    '--no-coverage',
+    'test/typescript/*.ts'
+  ]
+
+  const child = exec(args.join(' '), {
+    shell: true
+  })
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  child.once('close', process.exit)
+}


### PR DESCRIPTION
# What I did

- Add [tsm](https://github.com/lukeed/tsm) loader support so that people can run typescript via `tsm` require hook.

- Add a test code that runs in a non-TS node environment.

- Please let me know if the PR is okay.
I'm sorry, but I'm not sure about the benchmark, I could not found the `npm run benchmark`

---

#### Checklist

- [x] run `npm run test`[o] and `npm run benchmark`[x]
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
