### PR TITLE
fix (test): fixed some flacky tests and updated typescript definitions

### DIFF
--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -1,7 +1,7 @@
 /* eslint no-redeclare: off */
 /* eslint no-unused-vars: off */
 
-import { FastifyPlugin, FastifyPluginOptions } from 'fastify'
+import { FastifyPluginCallback, FastifyPluginOptions } from 'fastify'
 
 export interface AutoloadPluginOptions {
   dir: string
@@ -19,7 +19,7 @@ export interface AutoloadPluginOptions {
   routeParams?: boolean
 }
 
-declare const fastifyAutoload: FastifyPlugin<AutoloadPluginOptions>
+declare const fastifyAutoload: FastifyPluginCallback<AutoloadPluginOptions>
 
 type RewritePrefix = (folderParent: string, folderName: string) => string | boolean
 

--- a/package.json
+++ b/package.json
@@ -38,29 +38,29 @@
   },
   "homepage": "https://github.com/fastify/fastify-autoload#readme",
   "devDependencies": {
-    "@swc/core": "^1.2.85",
-    "@swc/register": "^0.1.7",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^17.0.0",
+    "@swc/core": "^1.2.129",
+    "@swc/register": "^0.1.9",
+    "@types/jest": "^27.4.0",
+    "@types/node": "^17.0.8",
     "@types/tap": "^15.0.5",
-    "fastify": "^3.0.0",
+    "fastify": "^3.25.3",
     "fastify-plugin": "^3.0.0",
     "fastify-url-data": "^3.0.3",
-    "jest": "^27.0.0",
+    "jest": "^27.4.7",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
-    "standard": "^16.0.1",
-    "tap": "^15.0.0",
-    "ts-jest": "^27.0.0",
-    "ts-node": "^10.1.0",
-    "ts-node-dev": "^1.1.1",
-    "tsd": "^0.19.0",
+    "standard": "^16.0.4",
+    "tap": "^15.1.6",
+    "ts-jest": "^27.1.3",
+    "ts-node": "^10.4.0",
+    "ts-node-dev": "^1.1.8",
+    "tsd": "^0.19.1",
     "tsm": "^2.2.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.5.4"
   },
   "dependencies": {
     "pkg-up": "^3.1.0",
-    "semver": "^7.3.2"
+    "semver": "^7.3.5"
   },
   "standard": {
     "ignore": [

--- a/test/typescript-esm/forceESM.ts
+++ b/test/typescript-esm/forceESM.ts
@@ -21,7 +21,7 @@ app.ready(function (err): void {
     function (err, res): void {
       t.error(err)
       t.equal(res.statusCode, 200)
-      t.deepEqual(JSON.parse(res.payload), { result: 'ok' })
+      t.same(JSON.parse(res.payload), { result: 'ok' })
     }
   )
 })

--- a/test/typescript-jest/basic/app.ts
+++ b/test/typescript-jest/basic/app.ts
@@ -1,8 +1,8 @@
-import { FastifyPlugin } from 'fastify'
+import { FastifyPluginCallback } from 'fastify'
 import { join } from 'path'
-const fastifyAutoLoad = require('../../../')
+const fastifyAutoLoad = require('../../../index')
 
-const app: FastifyPlugin = function (fastify, opts, next): void {
+const app: FastifyPluginCallback = function (fastify, opts, next): void {
   fastify.register(fastifyAutoLoad, {
     dir: join(__dirname, 'foo'),
   })

--- a/test/typescript-jest/basic/foo/typescript.ts
+++ b/test/typescript-jest/basic/foo/typescript.ts
@@ -1,6 +1,6 @@
-import { FastifyPlugin } from 'fastify'
+import { FastifyPluginCallback } from 'fastify'
 
-const plugin: FastifyPlugin = function (fastify, opts, next): void {
+const plugin: FastifyPluginCallback = function (fastify, opts, next): void {
   fastify.get('/typescript', (request, reply): void => {
     reply.send({ script: 'type' })
   })

--- a/test/typescript-jest/integration/integration.test.ts
+++ b/test/typescript-jest/integration/integration.test.ts
@@ -21,6 +21,6 @@ describe("integration test", function () {
         });
       });
     },
-    10000
+    30000
   );
 });

--- a/test/typescript/basic.ts
+++ b/test/typescript/basic.ts
@@ -17,7 +17,7 @@ app.ready(function (err): void {
   }, function (err, res): void {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.deepEqual(JSON.parse(res.payload), { script: 'java' })
+    t.same(JSON.parse(res.payload), { script: 'java' })
   })
 
   app.inject({
@@ -25,6 +25,6 @@ app.ready(function (err): void {
   }, function (err, res): void {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.deepEqual(JSON.parse(res.payload), { script: 'type' })
+    t.same(JSON.parse(res.payload), { script: 'type' })
   })
 })

--- a/test/typescript/basic.ts
+++ b/test/typescript/basic.ts
@@ -3,28 +3,30 @@ import fastify from 'fastify'
 
 import basicApp from './basic/app'
 
-t.plan(7)
+t.plan(5)
 
 const app = fastify()
 
 app.register(basicApp)
 
-app.ready(function (err): void {
+app.ready(async function (err): Promise<void> {
   t.error(err)
 
-  app.inject({
+  await app.inject({
     url: '/javascript'
-  }, function (err, res): void {
-    t.error(err)
+  }).then(function (res): void {
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { script: 'java' })
+  }).catch((err) => {
+    t.error(err)
   })
 
-  app.inject({
+  await app.inject({
     url: '/typescript'
-  }, function (err, res): void {
-    t.error(err)
+  }).then(function (res): void {
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { script: 'type' })
+  }).catch((err) => {
+    t.error(err)
   })
 })

--- a/test/typescript/basic/app.ts
+++ b/test/typescript/basic/app.ts
@@ -1,8 +1,8 @@
-import { FastifyPlugin } from 'fastify'
+import { FastifyPluginCallback } from 'fastify'
 import { join } from 'path'
 import fastifyAutoLoad from '../../../'
 
-const app: FastifyPlugin = function (fastify, opts, next): void {
+const app: FastifyPluginCallback = function (fastify, opts, next): void {
   fastify.register(fastifyAutoLoad, {
     dir: join(__dirname, 'foo'),
   })

--- a/test/typescript/basic/foo/typescript.ts
+++ b/test/typescript/basic/foo/typescript.ts
@@ -1,6 +1,6 @@
-import { FastifyPlugin } from 'fastify'
+import { FastifyPluginCallback } from 'fastify'
 
-const plugin: FastifyPlugin = function (fastify, opts, next): void {
+const plugin: FastifyPluginCallback = function (fastify, opts, next): void {
   fastify.get('/typescript', (request, reply): void => {
     reply.send({ script: 'type' })
   })

--- a/test/typescript/definitions/fastify-autoload.test-d.ts
+++ b/test/typescript/definitions/fastify-autoload.test-d.ts
@@ -1,10 +1,10 @@
-import fastify, { FastifyInstance, FastifyPlugin } from 'fastify'
+import fastify, { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import { expectType } from 'tsd'
-import * as fastifyAutoloadStar from "../../../"
-import fastifyAutoloadDefault, { AutoloadPluginOptions, fastifyAutoload as fastifyAutoloadNamed } from "../../../"
+import * as fastifyAutoloadStar from '../../../'
+import fastifyAutoloadDefault, { AutoloadPluginOptions, fastifyAutoload as fastifyAutoloadNamed } from '../../../'
 
-import fastifyAutoloadCjsImport = require("../../../")
-const fastifyAutoloadCjs = require("../../../")
+import fastifyAutoloadCjsImport = require('../../../')
+const fastifyAutoloadCjs = require('../../../')
 
 const app: FastifyInstance = fastify();
 app.register(fastifyAutoloadNamed);
@@ -15,12 +15,12 @@ app.register(fastifyAutoloadCjsImport.fastifyAutoload);
 app.register(fastifyAutoloadStar.default);
 app.register(fastifyAutoloadStar.fastifyAutoload);
 
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadNamed);
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadDefault);
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadCjsImport.default);
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadCjsImport.fastifyAutoload);
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadStar.default);
-expectType<FastifyPlugin<AutoloadPluginOptions>>(fastifyAutoloadStar.fastifyAutoload);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadNamed);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadDefault);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadCjsImport.default);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadCjsImport.fastifyAutoload);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadStar.default);
+expectType<FastifyPluginCallback<AutoloadPluginOptions>>(fastifyAutoloadStar.fastifyAutoload);
 expectType<any>(fastifyAutoloadCjs);
 
 let opt1: AutoloadPluginOptions = {


### PR DESCRIPTION
Hello.

This PR aims to :
- fix some flacky tests that randomly failed on CI runs
- update some deprecated tap `deepEqual` tests to the recommended `same` function
- update typescript definitions and tests
- upgrade package dependencies

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
