### PR TITLE
feat: adding `encapsulate` option with default `true`, non-breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Autoload can be customised using the following options:
     forceESM: true
   })
   ```
+- `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
+
+  ```js
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    encapsulate: false
+  })
+  ```
 
 - `options` (optional) - Global options object used for all registered plugins
 
@@ -192,7 +200,7 @@ Autoload can be customised using the following options:
   })
   ```
 
-  If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/master/docs/Encapsulation.md)
+  If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
   and decorated values _will not be exported_ outside the folder.
 
 - `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention

--- a/fastify-autoload.d.ts
+++ b/fastify-autoload.d.ts
@@ -12,6 +12,7 @@ export interface AutoloadPluginOptions {
   options?: FastifyPluginOptions
   maxDepth?: number
   forceESM?: boolean
+  encapsulate?: boolean
   autoHooks?: boolean
   autoHooksPattern?: RegExp
   cascadeHooks?: boolean

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ const defaults = {
   scriptPattern: /((^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
   indexPattern: /^index(\.ts|\.js|\.cjs|\.mjs)$/i,
   autoHooksPattern: /^[_.]?auto_?hooks(\.ts|\.js|\.cjs|\.mjs)$/i,
-  dirNameRoutePrefix: true
+  dirNameRoutePrefix: true,
+  encapsulate: true
 }
 
 const fastifyAutoload = async function autoload (fastify, options) {
@@ -217,7 +218,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 }
 
 async function loadPlugin (file, type, directoryPrefix, options) {
-  const { options: overrideConfig, forceESM } = options
+  const { options: overrideConfig, forceESM, encapsulate } = options
   let content
   if (forceESM || type === 'module') {
     content = await import(url.pathToFileURL(file).href)
@@ -229,6 +230,10 @@ async function loadPlugin (file, type, directoryPrefix, options) {
   const pluginConfig = (content.default && content.default.autoConfig) || content.autoConfig || {}
   const pluginOptions = Object.assign({}, pluginConfig, overrideConfig)
   const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
+
+  if (!encapsulate) {
+    plugin[Symbol.for('skip-override')] = true
+  }
 
   if (plugin.autoload === false || content.autoload === false) {
     return

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "fastify-autoload.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
+    "lint:fix": "standard --fix | snazzy",
     "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:tsm",
     "typescript": "tsd",
     "typescript:jest": "jest",

--- a/test/commonjs/basic.js
+++ b/test/commonjs/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(98)
+t.plan(101)
 
 const app = Fastify()
 
@@ -261,5 +261,13 @@ app.ready(function (err) {
 
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { works: true, id1: 'abc', id2: '2' })
+  })
+
+  app.inject({
+    url: '/encapsulate'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { works: true })
   })
 })

--- a/test/commonjs/basic/app.js
+++ b/test/commonjs/basic/app.js
@@ -56,6 +56,11 @@ module.exports = function (fastify, opts, next) {
     routeParams: true
   })
 
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'encapsulate'),
+    encapsulate: false
+  })
+
   const skipDir = path.join(__dirname, 'skip')
   fs.mkdir(path.join(skipDir, 'empty'), () => {
     fastify.register(autoLoad, {

--- a/test/commonjs/basic/encapsulate/plugin1.js
+++ b/test/commonjs/basic/encapsulate/plugin1.js
@@ -1,0 +1,10 @@
+module.exports = (fastify, opts, done) => {
+  fastify.decorateRequest('sharedVar', '')
+
+  fastify.addHook('onRequest', (request, reply, done) => {
+    fastify.sharedVar = true
+    done()
+  })
+
+  done()
+}

--- a/test/commonjs/basic/encapsulate/plugin2.js
+++ b/test/commonjs/basic/encapsulate/plugin2.js
@@ -1,0 +1,17 @@
+module.exports = async (fastify, opts, next) => {
+  fastify.get('/encapsulate', {
+    handler: async (request, reply) => {
+      reply.status(200).send({ works: fastify.sharedVar })
+    },
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            works: { type: 'boolean' }
+          }
+        }
+      }
+    }
+  })
+}

--- a/test/typescript/definitions/fastify-autoload.test-d.ts
+++ b/test/typescript/definitions/fastify-autoload.test-d.ts
@@ -57,6 +57,10 @@ const opt7: AutoloadPluginOptions = {
   cascadeHooks: true,
   overwriteHooks: true,
 }
+const opt8: AutoloadPluginOptions = {
+  dir: 'test',
+  encapsulate: false,
+}
 app.register(fastifyAutoloadDefault, opt1)
 app.register(fastifyAutoloadDefault, opt2)
 app.register(fastifyAutoloadDefault, opt3)
@@ -64,3 +68,4 @@ app.register(fastifyAutoloadDefault, opt4)
 app.register(fastifyAutoloadDefault, opt5)
 app.register(fastifyAutoloadDefault, opt6)
 app.register(fastifyAutoloadDefault, opt7)
+app.register(fastifyAutoloadDefault, opt8)


### PR DESCRIPTION
Adding the option below:

`encapsulate` (optional) - Defaults to `true`, if set to `false` each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.

  ```js
  fastify.register(autoLoad, {
    dir: path.join(__dirname, 'plugins'),
    encapsulate: false
  })
  ```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
