### PR TITLE
adds mixed route params

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Autoload can be customised using the following options:
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'plugins'),
     autoHooks: true, // apply hooks to routes in this level,
-    cascadeHooks: true // continue applying hooks to children, starting at this level    
+    cascadeHooks: true // continue applying hooks to children, starting at this level
   })
   ```
 
@@ -240,11 +240,17 @@ Autoload can be customised using the following options:
 
 - `routeParams` (optional) - Folders prefixed with `_` will be turned into route parameters.
 
+  If you want to use mixed route parameters use a double underscore `__`.
+
   ```js
   /*
   ├── routes
+  ├── __country-__language
+  │   │  └── actions.js
   │   └── users
   │       ├── _id
+  │       │   └── actions.js
+  │       ├── __country-__language
   │       │   └── actions.js
   │       └── index.js
   └── app.js
@@ -252,8 +258,10 @@ Autoload can be customised using the following options:
 
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'routes'),
-    routeParams: true // routes/users/_id/actions.js will be loaded with prefix /users/:id
-  })  
+    routeParams: true
+    // routes/users/_id/actions.js will be loaded with prefix /users/:id
+    // routes/__country-__language/actions.js will be loaded with prefix /:country-:language
+  })
 
   // curl http://localhost:3000/users/index
   // { userIndex: [ { id: 7, username: 'example' } ] }
@@ -261,6 +269,8 @@ Autoload can be customised using the following options:
   // curl http://localhost:3000/users/7/details
   // { user: { id: 7, username: 'example' } }
 
+  // curl http://localhost:3000/be-nl
+  // { country: 'be', language: 'nl' }
   ```
 
 ## Plugin Configuration
@@ -414,7 +424,7 @@ Each plugin can be individually configured using the following module properties
   ## Autohooks:
 
   The autohooks functionality provides several options for automatically embedding hooks, decorators, etc. to your routes. CJS and ESM `autohook` formats are supported.
-  
+
   The default behaviour of `autoHooks: true` is to encapsulate the `autohooks.js` plugin with the contents of the folder containing the file. The `cascadeHooks: true` option encapsulates the hooks with the current folder contents and all subsequent children, with any additional `autohooks.js` files being applied cumulatively. The `overwriteHooks: true` option will re-start the cascade any time an `autohooks.js` file is encountered.
 
   Plugins and hooks are encapsulated together by folder and registered on the `fastify` instance which loaded the `fastify-autoload` plugin. For more information on how encapsulation works in Fastify, see: https://www.fastify.io/docs/latest/Encapsulation/
@@ -470,7 +480,7 @@ Each plugin can be individually configured using the following module properties
     $ curl http://localhost:3000/hooked-plugin/children/new
     {}
 
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/ 
+    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
     { hookTwo: 'yes' }
     ```
 
@@ -486,7 +496,7 @@ Each plugin can be individually configured using the following module properties
     $ curl http://localhost:3000/hooked-plugin/children/new
     { hookOne: 'yes' }
 
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/ 
+    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
     { hookOne: 'yes', hookTwo: 'yes' } # hooks are accumulated and applied in ascending order
     ```
 
@@ -502,7 +512,7 @@ Each plugin can be individually configured using the following module properties
     $ curl http://localhost:3000/hooked-plugin/children/new
     { hookOne: 'yes' }
 
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/ 
+    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
     { hookTwo: 'yes' } # new autohooks.js takes over
     ```
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const isTsm = process._preload_modules && process._preload_modules.includes('tsm
 const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNode || isTsm
 const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 const routeParamPattern = /\/_/ig
-const routeMixedParamPattern = /\/.*__.*/ig
+const routeMixedParamPattern = /__/g
 
 const defaults = {
   scriptPattern: /((^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
@@ -57,7 +57,7 @@ const fastifyAutoload = async function autoload (fastify, options) {
     const isMixedRouteParam = pattern.match(routeMixedParamPattern)
 
     if (isMixedRouteParam) {
-      return pattern.replaceAll('__', ':')
+      return pattern.replace(routeMixedParamPattern, ':')
     } else if (isRegularRouteParam) {
       return pattern.replace(routeParamPattern, '/:')
     } else {

--- a/test/commonjs/route-parameters-basic.js
+++ b/test/commonjs/route-parameters-basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(10)
+t.plan(13)
 
 const app = Fastify()
 
@@ -37,5 +37,14 @@ app.ready(function (err) {
 
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { user: { id: '_id', username: 'example' } })
+  })
+
+  app.inject({
+    url: '/be-nl'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { country: 'be', language: 'nl' })
   })
 })

--- a/test/commonjs/route-parameters/routes/__country-__language/actions.js
+++ b/test/commonjs/route-parameters/routes/__country-__language/actions.js
@@ -1,0 +1,5 @@
+module.exports = async function (app, opts, next) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send(req.params)
+  })
+}


### PR DESCRIPTION
This fixes #197 and allows multiple route params to be configure in the path name. 

I've opted to use an additional route prefix (`__`) since folders and routes could contain a regular `_` in the name and that could break auto loading in unexpected ways.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
