### PR TITLE
docs(readme): replace use of deprecated variadic `listen()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ app.register(autoload, {
   dir: path.join(__dirname, 'plugins')
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 or with ESM syntax:
@@ -46,7 +46,7 @@ app.register(autoLoad, {
   dir: join(__dirname, 'plugins')
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })
 ```
 
 Folder structure:


### PR DESCRIPTION
See https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
