### PR TITLE
Add support for @swc-node/register

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ const pkgUp = require('pkg-up')
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
+const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
 const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
 const isTsx = process._preload_modules && process._preload_modules.toString().includes('tsx')
-const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNode || isTsm || isTsx
+const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
 const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:tsm && npm run typescript:tsx",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
     "typescript:swc": "node scripts/unit-typescript-swc.js",
+    "typescript:swc-node-register": "node scripts/unit-typescript-swc-node-register.js",
     "typescript:tsm": "node scripts/unit-typescript-tsm.js",
     "typescript:tsx": "node scripts/unit-typescript-tsx.js",
     "unit": "node scripts/unit.js",
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@fastify/url-data": "^5.0.0",
+    "@swc-node/register": "^1.5.1",
     "@swc/core": "^1.2.129",
     "@swc/register": "^0.1.9",
     "@types/jest": "^28.1.6",

--- a/scripts/unit-typescript-swc-node-register.js
+++ b/scripts/unit-typescript-swc-node-register.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { exec } = require('child_process')
+const semver = require('semver')
+
+if (semver.satisfies(process.version, '>= 14')) {
+  const args = [
+    'tap',
+    '--node-arg=--require=@swc-node/register',
+    '--no-coverage',
+    'test/typescript/*.ts'
+  ]
+
+  const child = exec(args.join(' '), {
+    shell: true
+  })
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  child.once('close', process.exit)
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This adds support for [@swc-node/register](https://github.com/swc-project/swc-node), a ts-node alternative from the SWC project.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
  *I ran the tests, but there is no benchmark script.*
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added *n/a*
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Note that although I added a TypeScript unit test file for this change, I could not get the test to *fail*, even before adding my changes to `typescriptSupport`.

An additional question: Would you be open to adding a `FASTIFY_AUTOLOAD_TS` environment variable that can be used to force TypeScript support? Otherwise, I feel people are going to hack things like setting `JEST_WORKER_ID` when they have TypeScript support, but this package isn't aware of it.
