### PR TITLE
Add support for .ts files when app is not run with ts-node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,12 @@ const url = require('url')
 const { readdir } = require('fs').promises
 const pkgUp = require('pkg-up')
 
-// const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
 const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
 const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
 const isTsx = process._preload_modules && process._preload_modules.toString().includes('tsx')
-// const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
 const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g
 

--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ const url = require('url')
 const { readdir } = require('fs').promises
 const pkgUp = require('pkg-up')
 
-const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
+// const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
 const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
 const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
 const isTsx = process._preload_modules && process._preload_modules.toString().includes('tsx')
-const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
+// const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
 const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g
 
@@ -162,8 +162,12 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
   if (indexDirent) {
     const file = path.join(dir, indexDirent.name)
     const type = getScriptType(file, options.packageType)
-    if (type === 'typescript' && !typescriptSupport) {
-      throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+    if (tsFileNoTsSupport()) {
+      try {
+        require('ts-node').register()
+      } catch {
+        throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+      }
     }
 
     hookedAccumulator[prefix || '/'].plugins.push({ file, type, prefix })
@@ -215,8 +219,12 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
     if (dirent.isFile() && scriptPattern.test(dirent.name)) {
       const type = getScriptType(file, options.packageType)
-      if (type === 'typescript' && !typescriptSupport) {
-        throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+      if (tsFileNoTsSupport()) {
+        try {
+          require('ts-node').register()
+        } catch {
+          throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+        }
       }
 
       // Don't place hook in plugin queue
@@ -341,6 +349,13 @@ function enrichError (err) {
     err.message += ' at ' + err.stack.split('\n')[0]
   }
   return err
+}
+
+function tsFileNoTsSupport () {
+  const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
+  const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
+  // return isTsNode && !typescriptSupport
+  return isTsNode === false && typescriptSupport === false
 }
 
 // do not create a new context, do not encapsulate

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx && npm run vitest",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
@@ -17,7 +17,8 @@
     "typescript:tsx": "node scripts/unit-typescript-tsx.js",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
-    "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
+    "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts",
+    "vitest": "vitest run"
   },
   "repository": {
     "type": "git",
@@ -61,7 +62,9 @@
     "tsd": "^0.23.0",
     "tsm": "^2.2.1",
     "tsx": "^3.7.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.4",
+    "vite": "^3.0.9",
+    "vitest": "^0.22.1"
   },
   "dependencies": {
     "pkg-up": "^3.1.0"

--- a/test/commonjs/ts-node.js
+++ b/test/commonjs/ts-node.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const AutoLoad = require('../../')
+const { join } = require('path')
+
+t.plan(7)
+
+const app = Fastify()
+
+app.register(AutoLoad, {
+  dir: join(__dirname, 'ts-node/routes')
+})
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  app.inject({
+    url: '/foo'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { foo: 'bar' })
+  })
+})

--- a/test/commonjs/ts-node/routes/foo/index.ts
+++ b/test/commonjs/ts-node/routes/foo/index.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { foo: "bar" };
+  })
+};

--- a/test/commonjs/ts-node/routes/root.ts
+++ b/test/commonjs/ts-node/routes/root.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { hello: "world" };
+  })
+};

--- a/test/vitest/basic.test.ts
+++ b/test/vitest/basic.test.ts
@@ -1,0 +1,29 @@
+'use strict'
+
+import { describe, test, expect } from 'vitest'
+import Fastify from 'fastify'
+import AutoLoad from '../../'
+import { join } from 'path'
+
+describe.concurrent("Vitest test suite", function () {
+  const app = Fastify()
+    app.register(AutoLoad, {
+      dir: join(__dirname, '../commonjs/ts-node/routes')
+    })
+  test("Test the root route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(JSON.parse(response.payload)).toEqual({ hello: 'world' })
+  })
+  test("Test /foo route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo'
+    })
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload)).toEqual({ foo: 'bar' })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/vitest/**/*.test.ts']
+    // ...
+  },
+})


### PR DESCRIPTION
This branch adds support for `.ts` files when the application is not run with `ts-node.` The specific use case for this is mentioned in #230. Vitest does not run with `ts-node` (it uses `es-build`) to compile TypeScript. This creates a situation where some`.ts` files that AutoLoad tries to import fails because there is no Typescript transpiler.

This pull request resolves #230.

### To make the tests fail
Replace lines 32-42 in `test/commonjs/error.js` with `app3.register(require('./index-error/app'))`. This will cause the plugin to load `ts-node` from the Node modules and not throw an error to the user that they need to install `ts-node`.

Replace `index.js` with the current version of the file in the `master` branch. This will cause the test files in `test/commonjs/ts-node.js` to error because it cannot load `.ts` files without either being run with ts-node or the ts-node `register` that is added in this branch.

## Notes
I did not modify any documentation as the error messages in `index.js` will still make sense. Happy to revise the documentation if requested.

Per request, I added `vite` and `vitest` as devDependencies and added some vitest tests so that we don't lose vitest support. 

Also happy to make any changes needed to this. Thanks for reviewing!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin]
