### PR TITLE
Skip loading of non-plugin-like entities

### DIFF
--- a/test/commonjs/non-plugin.js
+++ b/test/commonjs/non-plugin.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// This test tests that automatic loading will skip modules that do not
+// export a function, i.e. not a fastify plugin.
+
+const t = require('tap')
+const fastify = require('fastify')
+
+t.plan(4)
+
+const app = fastify()
+
+app.register(require('./non-plugin/app'))
+
+app.ready(err => {
+  t.error(err)
+
+  app.inject({
+    url: '/foo'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(res.payload, 'foo')
+  })
+})

--- a/test/commonjs/non-plugin/app.js
+++ b/test/commonjs/non-plugin/app.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const path = require('path')
+const AutoLoad = require('../../../')
+
+module.exports = function (fastify, opts, next) {
+  fastify.register(AutoLoad, {
+    dir: path.join(__dirname, 'lib')
+  })
+
+  next()
+}

--- a/test/commonjs/non-plugin/lib/a-plugin.js
+++ b/test/commonjs/non-plugin/lib/a-plugin.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (server) {
+  server.get('/foo', function (req, reply) {
+    reply.send('foo')
+  })
+}

--- a/test/commonjs/non-plugin/lib/non-plugin.js
+++ b/test/commonjs/non-plugin/lib/non-plugin.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  foo: 'foo'
+}


### PR DESCRIPTION
If this plugin encounters an export like:

```js
module.exports = {
  foo: 'foo'
}
```

It will attempt to load it like any other Fastify plugin. This results in `avvio` complaining that it received an object when it was expecting a function. Such an error is _very_ difficult to track down because the offending source file reference is long lost by the time `avvio` is involved. In order to prevent this, this pull request adds code to validate the required data as being either a legitimate Fastify plugin, or an object that can be reasonably assumed to be capable of becoming one (i.e. wrapped into a plugin automatically). Otherwise, it will silently ignore that file.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
