### PR TITLE
271: trying to use babel-node when using typescript files

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,13 +162,11 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
   if (indexDirent) {
     const file = path.join(dir, indexDirent.name)
     const type = getScriptType(file, options.packageType)
-    if (type === 'typescript') {
-      if (!typescriptSupport) {
-        try {
-          require('ts-node').register()
-        } catch (e) {
-          throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
-        }
+    if (type === 'typescript' && !typescriptSupport) {
+      try {
+        require('ts-node').register()
+      } catch (e) {
+        throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
       }
     }
 
@@ -221,13 +219,11 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
     if (dirent.isFile() && scriptPattern.test(dirent.name)) {
       const type = getScriptType(file, options.packageType)
-      if (type === 'typescript') {
-        if (!typescriptSupport) {
-          try {
-            require('ts-node').register()
-          } catch (e) {
-            throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
-          }
+      if (type === 'typescript' && !typescriptSupport) {
+        try {
+          require('ts-node').register()
+        } catch (e) {
+          throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const { readdir } = require('fs').promises
 const pkgUp = require('pkg-up')
 
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
-const isBabelNode = process?.execArgv.some((arg) => arg.indexOf('babel-node') >= 0)
+const isBabelNode = (process?.execArgv || []).concat(process?.argv || []).some((arg) => arg.indexOf('babel-node') >= 0)
+
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
 const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')

--- a/index.js
+++ b/index.js
@@ -162,8 +162,14 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
   if (indexDirent) {
     const file = path.join(dir, indexDirent.name)
     const type = getScriptType(file, options.packageType)
-    if (type === 'typescript' && !typescriptSupport) {
-      throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+    if (type === 'typescript') {
+      if (!typescriptSupport) {
+        try {
+          require('ts-node').register()
+        } catch (e) {
+          throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+        }
+      }
     }
 
     hookedAccumulator[prefix || '/'].plugins.push({ file, type, prefix })
@@ -215,8 +221,14 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
     if (dirent.isFile() && scriptPattern.test(dirent.name)) {
       const type = getScriptType(file, options.packageType)
-      if (type === 'typescript' && !typescriptSupport) {
-        throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+      if (type === 'typescript') {
+        if (!typescriptSupport) {
+          try {
+            require('ts-node').register()
+          } catch (e) {
+            throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+          }
+        }
       }
 
       // Don't place hook in plugin queue

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ const { readdir } = require('fs').promises
 const pkgUp = require('pkg-up')
 
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
+const isBabelNode = process?.execArgv.some((arg) => arg.indexOf('babel-node') >= 0)
 const isJestEnvironment = process.env.JEST_WORKER_ID !== undefined
 const isSWCRegister = process._preload_modules && process._preload_modules.includes('@swc/register')
 const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
 const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
 const isTsx = process._preload_modules && process._preload_modules.toString().includes('tsx')
-const typescriptSupport = isTsNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
+const typescriptSupport = isTsNode || isBabelNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
 const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g
 
@@ -163,11 +164,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
     const file = path.join(dir, indexDirent.name)
     const type = getScriptType(file, options.packageType)
     if (type === 'typescript' && !typescriptSupport) {
-      try {
-        require('ts-node').register()
-      } catch (e) {
-        throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
-      }
+      throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
     }
 
     hookedAccumulator[prefix || '/'].plugins.push({ file, type, prefix })
@@ -220,11 +217,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
     if (dirent.isFile() && scriptPattern.test(dirent.name)) {
       const type = getScriptType(file, options.packageType)
       if (type === 'typescript' && !typescriptSupport) {
-        try {
-          require('ts-node').register()
-        } catch (e) {
-          throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
-        }
+        throw new Error(`@fastify/autoload cannot import plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
       }
 
       // Don't place hook in plugin queue

--- a/test/commonjs/babel-node.js
+++ b/test/commonjs/babel-node.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('fastify')
+const AutoLoad = require('../../')
+const { join } = require('path')
+
+t.plan(7)
+
+const app = Fastify()
+
+app.register(AutoLoad, {
+  dir: join(__dirname, 'babel-node/routes')
+})
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { hello: 'world' })
+  })
+
+  app.inject({
+    url: '/foo'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { foo: 'bar' })
+  })
+})

--- a/test/commonjs/babel-node/routes/foo/index.ts
+++ b/test/commonjs/babel-node/routes/foo/index.ts
@@ -1,0 +1,5 @@
+module.exports = async (fastify) => {
+  fastify.get("/", function () {
+    return { foo: "bar" };
+  })
+};

--- a/test/commonjs/babel-node/routes/root.ts
+++ b/test/commonjs/babel-node/routes/root.ts
@@ -1,0 +1,5 @@
+module.exports = async (fastify) => {
+  fastify.get("/", function () {
+    return { hello: "world" };
+  })
+};

--- a/test/typescript-jest/babel-node/index.test.ts
+++ b/test/typescript-jest/babel-node/index.test.ts
@@ -1,0 +1,31 @@
+import fastify from 'fastify'
+import { join } from 'path'
+import AutoLoad from '../../../'
+
+describe("load typescript using babel-node", () => {
+  const app = fastify()
+
+  beforeAll( done => {
+    app.register(AutoLoad, {
+      dir: join(__dirname, '../../commonjs/babel-node/routes')
+    })
+    app.ready(done)
+  })
+
+  it("tests the root route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(JSON.parse(response.payload)).toEqual({ hello: 'world' })
+  })
+  it("tests /foo route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo'
+    })
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload)).toEqual({ foo: 'bar' })
+  })
+})


### PR DESCRIPTION
- when dealing with typescript files, we need to make sure the ts-node is being used to autoload components
- closes: https://github.com/fastify/fastify-autoload/issues/271