### PR TITLE
Conditionally load tsnode for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
-    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx",
+    "test": "npm run lint && npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx && npm run typescript:vitest",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
@@ -15,6 +15,7 @@
     "typescript:swc-node-register": "node scripts/unit-typescript-swc-node-register.js",
     "typescript:tsm": "node scripts/unit-typescript-tsm.js",
     "typescript:tsx": "node scripts/unit-typescript-tsx.js",
+    "typescript:vitest": "vitest run",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
     "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
@@ -62,7 +63,9 @@
     "tsd": "^0.24.1",
     "tsm": "^2.2.1",
     "tsx": "^3.7.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.4",
+    "vite": "^3.1.7",
+    "vitest": "^0.24.1"
   },
   "dependencies": {
     "pkg-up": "^3.1.0"

--- a/test/commonjs/ts-node/routes/foo/index.ts
+++ b/test/commonjs/ts-node/routes/foo/index.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { foo: "bar" };
+  })
+};

--- a/test/commonjs/ts-node/routes/root.ts
+++ b/test/commonjs/ts-node/routes/root.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { hello: "world" };
+  })
+};

--- a/test/vitest/basic.test.ts
+++ b/test/vitest/basic.test.ts
@@ -1,0 +1,31 @@
+'use strict'
+
+import { describe, test, expect } from 'vitest'
+import Fastify from 'fastify'
+import AutoLoad from '../../index'
+import { join } from 'path'
+
+describe.concurrent("Vitest test suite", function () {
+  const app = Fastify()
+    app.register(AutoLoad, {
+      dir: join(__dirname, '../commonjs/ts-node/routes')
+    })
+
+  test("Test the root route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    expect(response.statusCode).toEqual(200)
+    expect(JSON.parse(response.payload)).toEqual({ hello: 'world' })
+  })
+
+  test("Test /foo route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo'
+    })
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.payload)).toEqual({ foo: 'bar' })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/vitest/**/*.test.ts']
+    // ...
+  },
+})


### PR DESCRIPTION
based on #264 

I think #264 was breaking, because of multiple reasons:

- it was not checking if we have a typescript file, and was probably always trying to load ts-node
- it was always trying to load ts-node even in production, which is bad

So this PR fixes that by checking if we even have a typescript file and if we are in vitest, it will load ts-node. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
