### PR TITLE
add esbuild-register support

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ const isSWCRegister = process._preload_modules && process._preload_modules.inclu
 const isSWCNodeRegister = process._preload_modules && process._preload_modules.includes('@swc-node/register')
 const isSWCNode = typeof process.env._ === 'string' && process.env._.includes('.bin/swc-node')
 const isTsm = process._preload_modules && process._preload_modules.includes('tsm')
+const isEsbuildRegister = process._preload_modules && process._preload_modules.includes('esbuild-register')
 const isTsx = process._preload_modules && process._preload_modules.toString().includes('tsx')
-const typescriptSupport = isTsNode || isVitestEnvironment || isBabelNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx
+const typescriptSupport = isTsNode || isVitestEnvironment || isBabelNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx || isEsbuildRegister
 const forceESMEnvironment = isVitestEnvironment || false
 const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:fix": "standard --fix | snazzy",
-    "test": "npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx && npm run typescript:vitest",
+    "test": "npm run unit && npm run typescript && npm run typescript:jest && npm run typescript:esm && npm run typescript:swc && npm run typescript:swc-node-register && npm run typescript:tsm && npm run typescript:tsx && npm run typescript:vitest && npm run typescript:esbuild",
     "typescript": "tsd",
     "typescript:jest": "jest",
     "typescript:esm": "node scripts/unit-typescript-esm.js",
@@ -15,6 +15,7 @@
     "typescript:swc-node-register": "node scripts/unit-typescript-swc-node-register.js",
     "typescript:tsm": "node scripts/unit-typescript-tsm.js",
     "typescript:tsx": "node scripts/unit-typescript-tsx.js",
+    "typescript:esbuild": "node scripts/unit-typescript-esbuild.js",
     "typescript:vitest": "vitest run",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
@@ -64,6 +65,8 @@
     "tsm": "^2.2.1",
     "tsx": "^3.7.1",
     "typescript": "^4.5.4",
+    "esbuild": "^0.15.14",
+    "esbuild-register": "^3.4.1",
     "vite": "^3.1.7",
     "vitest": "^0.25.2"
   },

--- a/scripts/unit-typescript-esbuild.js
+++ b/scripts/unit-typescript-esbuild.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { exec } = require('child_process')
+const semver = require('semver')
+
+if (semver.satisfies(process.version, '>= 14')) {
+  const args = [
+    'node',
+    '-r esbuild-register',
+    'test/typescript/basic.ts'
+  ]
+  const child = exec(args.join(' '), {
+    shell: true
+  })
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  child.once('close', process.exit)
+}


### PR DESCRIPTION
What I did
Add [esbuild-register](https://github.com/egoist/esbuild-register) support. One of the many libraries to execute typescript files on the fly

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
