### PR TITLE
remove semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "typescript:esbuild": "node scripts/unit-typescript-esbuild.js",
     "typescript:vitest": "vitest run",
     "unit": "node scripts/unit.js",
-    "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts",
-    "unit:without-modules": "tap test/commonjs/*.js test/typescript/*.ts"
+    "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts"
   },
   "repository": {
     "type": "git",
@@ -54,7 +53,6 @@
     "fastify": "^4.0.0-rc.2",
     "fastify-plugin": "^4.0.0",
     "jest": "^28.1.3",
-    "semver": "^7.3.7",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.0.0",

--- a/scripts/unit-typescript-esbuild.js
+++ b/scripts/unit-typescript-esbuild.js
@@ -1,19 +1,16 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'node',
-    '-r esbuild-register',
-    'test/typescript/basic.ts'
-  ]
-  const child = exec(args.join(' '), {
-    shell: true
-  })
+const args = [
+  'node',
+  '-r esbuild-register',
+  'test/typescript/basic.ts'
+]
+const child = exec(args.join(' '), {
+  shell: true
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit-typescript-esm.js
+++ b/scripts/unit-typescript-esm.js
@@ -1,32 +1,29 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'tap',
-    '--node-arg=--loader=ts-node/esm',
-    '--node-arg=--experimental-specifier-resolution=node',
-    '--no-coverage',
-    'test/typescript-esm/*.ts'
-  ]
+const args = [
+  'tap',
+  '--node-arg=--loader=ts-node/esm',
+  '--node-arg=--experimental-specifier-resolution=node',
+  '--no-coverage',
+  'test/typescript-esm/*.ts'
+]
 
-  const child = exec(args.join(' '), {
-    shell: true,
-    env: {
-      ...process.env,
-      TS_NODE_COMPILER_OPTIONS: JSON.stringify({
-        module: 'ESNext',
-        target: 'ES2020',
-        allowJs: false,
-        moduleResolution: 'node',
-        esModuleInterop: true
-      })
-    }
-  })
+const child = exec(args.join(' '), {
+  shell: true,
+  env: {
+    ...process.env,
+    TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+      module: 'ESNext',
+      target: 'ES2020',
+      allowJs: false,
+      moduleResolution: 'node',
+      esModuleInterop: true
+    })
+  }
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit-typescript-swc-node-register.js
+++ b/scripts/unit-typescript-swc-node-register.js
@@ -1,21 +1,18 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'tap',
-    '--node-arg=--require=@swc-node/register',
-    '--no-coverage',
-    'test/typescript/*.ts'
-  ]
+const args = [
+  'tap',
+  '--node-arg=--require=@swc-node/register',
+  '--no-coverage',
+  'test/typescript/*.ts'
+]
 
-  const child = exec(args.join(' '), {
-    shell: true
-  })
+const child = exec(args.join(' '), {
+  shell: true
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit-typescript-swc.js
+++ b/scripts/unit-typescript-swc.js
@@ -1,21 +1,18 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'tap',
-    '--node-arg=--require=@swc/register',
-    '--no-coverage',
-    'test/typescript/*.ts'
-  ]
+const args = [
+  'tap',
+  '--node-arg=--require=@swc/register',
+  '--no-coverage',
+  'test/typescript/*.ts'
+]
 
-  const child = exec(args.join(' '), {
-    shell: true
-  })
+const child = exec(args.join(' '), {
+  shell: true
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit-typescript-tsm.js
+++ b/scripts/unit-typescript-tsm.js
@@ -1,22 +1,19 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'tap',
-    '--no-ts',
-    '--node-arg=--require=tsm',
-    '--no-coverage',
-    'test/typescript/*.ts'
-  ]
+const args = [
+  'tap',
+  '--no-ts',
+  '--node-arg=--require=tsm',
+  '--no-coverage',
+  'test/typescript/*.ts'
+]
 
-  const child = exec(args.join(' '), {
-    shell: true
-  })
+const child = exec(args.join(' '), {
+  shell: true
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit-typescript-tsx.js
+++ b/scripts/unit-typescript-tsx.js
@@ -1,20 +1,17 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-if (semver.satisfies(process.version, '>= 14')) {
-  const args = [
-    'npx',
-    'tsx',
-    'test/typescript/basic.ts'
-  ]
+const args = [
+  'npx',
+  'tsx',
+  'test/typescript/basic.ts'
+]
 
-  const child = exec(args.join(' '), {
-    shell: true
-  })
+const child = exec(args.join(' '), {
+  shell: true
+})
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
-  child.once('close', process.exit)
-}
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+child.once('close', process.exit)

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -1,11 +1,8 @@
 'use strict'
 
 const { exec } = require('child_process')
-const semver = require('semver')
 
-const child = exec(semver.satisfies('>=14 || >= 12.17.0 < 13.0.0')
-  ? 'npm run unit:with-modules'
-  : 'npm run unit:without-modules')
+const child = exec('npm run unit:with-modules')
 
 child.stdout.pipe(process.stdout)
 child.stderr.pipe(process.stderr)

--- a/test/commonjs/error.js
+++ b/test/commonjs/error.js
@@ -2,9 +2,6 @@
 
 const t = require('tap')
 const fastify = require('fastify')
-const semver = require('semver')
-
-const moduleSupport = semver.satisfies(process.version, '>= 14 || >= 12.17.0 < 13.0.0')
 
 t.test('independent of module support', function (t) {
   t.plan(8)
@@ -44,17 +41,3 @@ t.test('independent of module support', function (t) {
     t.equal(err.message, 'Cyclic dependency')
   })
 })
-
-if (!moduleSupport) {
-  t.test('without moduleSupport', function (t) {
-    t.plan(2)
-    const app = fastify()
-
-    app.register(require('./module-error/app'))
-
-    app.ready(function (err) {
-      t.type(err, Error)
-      t.match(err.message, /cannot import plugin at .*mjs/i)
-    })
-  })
-}


### PR DESCRIPTION
We support node >= 14, so we dont need semver anymore.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
