### PR TITLE
Add matchFilter and ignoreFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,17 @@ Autoload can be customised using the following options:
   })
   ```
 
+- `matchPattern` (optional) - Filter matching any file that should be loaded. Can be a RegExp, a string or a function returning a boolean.
 
-- `ignorePattern` (optional) - Regex matching any file that should not be loaded
+  ```js
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    matchPattern: (path) => path.endsWith('-handler.js')
+  })
+  ```
+
+
+- `ignorePattern` (optional) - Filter matching any file that should not be loaded. Can be a RegExp, a string or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -118,6 +127,7 @@ Autoload can be customised using the following options:
     ignorePattern: /.*(test|spec).js/
   })
   ```
+
 
 - `indexPattern` (optional) - Regex to override the `index.js` naming convention
 

--- a/README.md
+++ b/README.md
@@ -109,17 +109,27 @@ Autoload can be customised using the following options:
   })
   ```
 
-- `matchPattern` (optional) - Filter matching any file that should be loaded. Can be a RegExp, a string or a function returning a boolean.
+- `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'plugins'),
-    matchPattern: (path) => path.endsWith('-handler.js')
+    matchFilter: (path) => path.split("/").at(-2) === "handlers"
   })
   ```
 
 
-- `ignorePattern` (optional) - Filter matching any file that should not be loaded. Can be a RegExp, a string or a function returning a boolean.
+- `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string or a function returning a boolean.
+
+  ```js
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'plugins'),
+    ignoreFilter: (path) => path.endsWith('.spec.js')
+  })
+  ```
+
+
+- `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
 
   ```js
   fastify.register(autoLoad, {

--- a/index.js
+++ b/index.js
@@ -238,16 +238,12 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
     const routePath = `${prefix ?? ''}/${direntName}`
 
     if (matchFilter && !filterPath(routePath, matchFilter)) {
-      console.log('skip ' + routePath)
       return
     }
 
     if (ignoreFilter && filterPath(routePath, ignoreFilter)) {
-      console.log('skip ' + routePath)
       return
     }
-
-    console.log('register ' + routePath)
 
     hookedAccumulator[prefix || '/'].plugins.push({ file, type, prefix })
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typescript:tsx": "node scripts/unit-typescript-tsx.js",
     "typescript:esbuild": "node scripts/unit-typescript-esbuild.js",
     "typescript:vitest": "vitest run",
+    "typescript:vitest:dev": "vitest",
     "unit": "node scripts/unit.js",
     "unit:with-modules": "tap test/commonjs/*.js test/module/*.js test/typescript/*.ts"
   },

--- a/test/commonjs/ts-node/routes/bar/index.ts
+++ b/test/commonjs/ts-node/routes/bar/index.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { foo: "bar" };
+  })
+};

--- a/test/commonjs/ts-node/routes/foo/baz/index.ts
+++ b/test/commonjs/ts-node/routes/foo/baz/index.ts
@@ -1,0 +1,5 @@
+module.exports.default = async (fastify: any) => {
+  fastify.get("/", function () {
+    return { foo: "bar" };
+  })
+};

--- a/test/vitest/filter.test.ts
+++ b/test/vitest/filter.test.ts
@@ -1,0 +1,70 @@
+'use strict'
+
+import { describe, test, expect } from 'vitest'
+import Fastify from 'fastify'
+import AutoLoad from '../../index'
+import { join } from 'path'
+
+describe.concurrent("Vitest ignore filters test suite", function () {
+  const app = Fastify()
+    app.register(AutoLoad, {
+      dir: join(__dirname, '../commonjs/ts-node/routes'),
+      ignorePattern: "foo"
+    })
+
+  test("Test the root route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    expect(response.statusCode).toEqual(200)
+  })
+
+    test("Test /foo route", async function () {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/foo'
+      })
+      expect(response.statusCode).toBe(404)
+    })
+
+    test("Test /bar route", async function () {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/bar'
+      })
+      expect(response.statusCode).toBe(200)
+    })
+})
+
+describe.concurrent("Vitest match filters test suite", function () {
+  const app = Fastify()
+  app.register(AutoLoad, {
+    dir: join(__dirname, '../commonjs/ts-node/routes'),
+    matchPattern: "foo"
+  })
+
+  test("Test the root route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/'
+    })
+    expect(response.statusCode).toEqual(404)
+  })
+
+  test("Test /foo route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo'
+    })
+    expect(response.statusCode).toBe(200)
+  })
+
+  test("Test /bar route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/bar'
+    })
+    expect(response.statusCode).toBe(404)
+  })
+})

--- a/test/vitest/filter.test.ts
+++ b/test/vitest/filter.test.ts
@@ -9,7 +9,7 @@ describe.concurrent("Vitest ignore filters test suite", function () {
   const app = Fastify()
     app.register(AutoLoad, {
       dir: join(__dirname, '../commonjs/ts-node/routes'),
-      ignorePattern: "foo"
+      ignoreFilter: "foo"
     })
 
   test("Test the root route", async function () {
@@ -20,28 +20,36 @@ describe.concurrent("Vitest ignore filters test suite", function () {
     expect(response.statusCode).toEqual(200)
   })
 
-    test("Test /foo route", async function () {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/foo'
-      })
-      expect(response.statusCode).toBe(404)
+  test("Test /foo route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo'
     })
+    expect(response.statusCode).toBe(404)
+  })
 
-    test("Test /bar route", async function () {
-      const response = await app.inject({
-        method: 'GET',
-        url: '/bar'
-      })
-      expect(response.statusCode).toBe(200)
+  test("Test /bar route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/bar'
     })
+    expect(response.statusCode).toBe(200)
+  })
+
+  test("Test /baz route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo/baz'
+    })
+    expect(response.statusCode).toBe(404)
+  })
 })
 
 describe.concurrent("Vitest match filters test suite", function () {
   const app = Fastify()
   app.register(AutoLoad, {
     dir: join(__dirname, '../commonjs/ts-node/routes'),
-    matchPattern: "foo"
+    matchFilter: "/foo"
   })
 
   test("Test the root route", async function () {
@@ -66,5 +74,13 @@ describe.concurrent("Vitest match filters test suite", function () {
       url: '/bar'
     })
     expect(response.statusCode).toBe(404)
+  })
+
+  test("Test /baz route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/foo/baz'
+    })
+    expect(response.statusCode).toBe(200)
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,13 +4,14 @@ type FastifyAutoloadPlugin = FastifyPluginCallback<NonNullable<fastifyAutoload.A
 
 declare namespace fastifyAutoload {
   type RewritePrefix = (folderParent: string, folderName: string) => string | boolean
-  type Filter = string | RegExp | ((value: string) => boolean)
+  type Filter = string | RegExp | ((value: {file: string; path: string}) => boolean)
 
   export interface AutoloadPluginOptions {
     dir: string
     dirNameRoutePrefix?: boolean | RewritePrefix
-    ignorePattern?: Filter
-    matchPattern?: Filter
+    ignoreFilter?: Filter
+    matchFilter?: Filter
+    ignorePattern?: RegExp
     scriptPattern?: RegExp
     indexPattern?: RegExp
     options?: FastifyPluginOptions

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,11 +4,13 @@ type FastifyAutoloadPlugin = FastifyPluginCallback<NonNullable<fastifyAutoload.A
 
 declare namespace fastifyAutoload {
   type RewritePrefix = (folderParent: string, folderName: string) => string | boolean
+  type Filter = string | RegExp | ((value: string) => boolean)
 
   export interface AutoloadPluginOptions {
     dir: string
     dirNameRoutePrefix?: boolean | RewritePrefix
-    ignorePattern?: RegExp
+    ignorePattern?: Filter
+    matchPattern?: Filter
     scriptPattern?: RegExp
     indexPattern?: RegExp
     options?: FastifyPluginOptions

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -61,6 +61,21 @@ const opt8: AutoloadPluginOptions = {
   dir: 'test',
   encapsulate: false,
 }
+const opt9: AutoloadPluginOptions = {
+  dir: 'test',
+  ignoreFilter: /test/,
+  matchFilter: /handler/
+}
+const opt10: AutoloadPluginOptions = {
+  dir: 'test',
+  ignoreFilter: 'test',
+  matchFilter: 'handler'
+}
+const opt11: AutoloadPluginOptions = {
+  dir: 'test',
+  ignoreFilter: ({file}) => file.endsWith('.spec.ts'),
+  matchFilter: ({path}) => path.split("/").at(-2) === 'handlers'
+}
 app.register(fastifyAutoloadDefault, opt1)
 app.register(fastifyAutoloadDefault, opt2)
 app.register(fastifyAutoloadDefault, opt3)
@@ -69,3 +84,6 @@ app.register(fastifyAutoloadDefault, opt5)
 app.register(fastifyAutoloadDefault, opt6)
 app.register(fastifyAutoloadDefault, opt7)
 app.register(fastifyAutoloadDefault, opt8)
+app.register(fastifyAutoloadDefault, opt9)
+app.register(fastifyAutoloadDefault, opt10)
+app.register(fastifyAutoloadDefault, opt11)


### PR DESCRIPTION
Fix #287 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

So, I added the `matchFilter` and `ignoreFilter` optional options that can accepts
- string
- RegExp
- function returning a boolean

I ended up letting `ignorePattern` as is for compatibility.
`ignorePattern` only check the file name, whereas `matchFilter` and `ignoreFilter` check the whole path (prefix + file name)

I added some tests and a documentation.