### PR TITLE
Fix: Incorrect Filter type

### DIFF
--- a/test/vitest/filter.test.ts
+++ b/test/vitest/filter.test.ts
@@ -49,7 +49,7 @@ describe.concurrent("Vitest match filters test suite", function () {
   const app = Fastify()
   app.register(AutoLoad, {
     dir: join(__dirname, '../commonjs/ts-node/routes'),
-    matchFilter: "/foo"
+    matchFilter: (path) => path.startsWith("/foo")
   })
 
   test("Test the root route", async function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ type FastifyAutoloadPlugin = FastifyPluginCallback<NonNullable<fastifyAutoload.A
 
 declare namespace fastifyAutoload {
   type RewritePrefix = (folderParent: string, folderName: string) => string | boolean
-  type Filter = string | RegExp | ((value: {file: string; path: string}) => boolean)
+  type Filter = string | RegExp | ((path: string) => boolean)
 
   export interface AutoloadPluginOptions {
     dir: string

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -73,8 +73,8 @@ const opt10: AutoloadPluginOptions = {
 }
 const opt11: AutoloadPluginOptions = {
   dir: 'test',
-  ignoreFilter: ({file}) => file.endsWith('.spec.ts'),
-  matchFilter: ({path}) => path.split("/").at(-2) === 'handlers'
+  ignoreFilter: (path) => path.endsWith('.spec.ts'),
+  matchFilter: (path) => path.split('/').at(-2) === 'handlers'
 }
 app.register(fastifyAutoloadDefault, opt1)
 app.register(fastifyAutoloadDefault, opt2)


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I'm so sorry, I messed up the typescript type as I changed filter functions prototype when developing this feature https://github.com/fastify/fastify-autoload/issues/287 😥 ...

Basically, at one point of dev, filter functions had a prototype of `({path:string, file:string})=>boolean`, but I changed it for `(path:string)=>boolean` since I found it more convenient. I used the correct prototype in the documentation, though.

I updated a test to use a filter functions.