### PR TITLE
Fix file path for filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
   function accumulatePlugin ({ file, type }) {
     // Replace backward slash to forward slash for consistent behavior between windows and posix.
-    const filePath = '/' + path.relative(options.dir, file).replaceAll('\\', '/')
+    const filePath = '/' + path.relative(options.dir, file).replace(/\\/g, '/')
 
     if (matchFilter && !filterPath(filePath, matchFilter)) {
       return

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
       throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
     }
 
-    accumulatePlugin({ file, type }, indexDirent.name)
+    accumulatePlugin({ file, type })
     const hasDirectory = list.find((dirent) => dirent.isDirectory())
 
     if (!hasDirectory) {
@@ -226,7 +226,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
       // Don't place hook in plugin queue
       if (!autoHooksPattern.test(dirent.name)) {
-        accumulatePlugin({ file, type }, dirent.name)
+        accumulatePlugin({ file, type })
       }
     }
   }
@@ -234,14 +234,15 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
   return hookedAccumulator
 
-  function accumulatePlugin ({ file, type }, direntName = 'index.ts') {
-    const routePath = `${prefix ?? ''}/${direntName}`
+  function accumulatePlugin ({ file, type }) {
+    // Replace backward slash to forward slash for consistent behavior between windows and posix.
+    const filePath = '/' + path.relative(options.dir, file).replaceAll('\\', '/')
 
-    if (matchFilter && !filterPath(routePath, matchFilter)) {
+    if (matchFilter && !filterPath(filePath, matchFilter)) {
       return
     }
 
-    if (ignoreFilter && filterPath(routePath, ignoreFilter)) {
+    if (ignoreFilter && filterPath(filePath, ignoreFilter)) {
       return
     }
 

--- a/test/commonjs/ts-node/routes/bar/index.ts
+++ b/test/commonjs/ts-node/routes/bar/index.ts
@@ -1,5 +1,5 @@
 module.exports.default = async (fastify: any) => {
   fastify.get("/", function () {
-    return { foo: "bar" };
+    return { bar: "bar" };
   })
 };

--- a/test/commonjs/ts-node/routes/foo/baz/index.ts
+++ b/test/commonjs/ts-node/routes/foo/baz/index.ts
@@ -1,5 +1,5 @@
 module.exports.default = async (fastify: any) => {
-  fastify.get("/", function () {
-    return { foo: "bar" };
+  fastify.get("/customPath", function () {
+    return { baz: "baz" };
   })
 };

--- a/test/commonjs/ts-node/routes/foo/index.ts
+++ b/test/commonjs/ts-node/routes/foo/index.ts
@@ -1,5 +1,5 @@
 module.exports.default = async (fastify: any) => {
   fastify.get("/", function () {
-    return { foo: "bar" };
+    return { foo: "foo" };
   })
 };

--- a/test/vitest/basic.test.ts
+++ b/test/vitest/basic.test.ts
@@ -26,6 +26,6 @@ describe.concurrent("Vitest test suite", function () {
       url: '/foo'
     })
     expect(response.statusCode).toBe(200)
-    expect(JSON.parse(response.payload)).toEqual({ foo: 'bar' })
+    expect(JSON.parse(response.payload)).toEqual({ foo: 'foo' })
   })
 })

--- a/test/vitest/filter.test.ts
+++ b/test/vitest/filter.test.ts
@@ -79,7 +79,24 @@ describe.concurrent("Vitest match filters test suite", function () {
   test("Test /baz route", async function () {
     const response = await app.inject({
       method: 'GET',
-      url: '/foo/baz'
+      url: '/foo/baz/customPath'
+    })
+    expect(response.statusCode).toBe(200)
+  })
+})
+
+describe.concurrent("Vitest match filters without prefix test suite", function () {
+  const app = Fastify()
+  app.register(AutoLoad, {
+    dir: join(__dirname, '../commonjs/ts-node/routes'),
+    dirNameRoutePrefix: false,
+    matchFilter: (path) => path.startsWith("/foo/baz")
+  })
+
+  test("Test /baz route", async function () {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/customPath'
     })
     expect(response.statusCode).toBe(200)
   })


### PR DESCRIPTION
Fix https://github.com/fastify/fastify-autoload/issues/291

I'm so sorry, the matchFilter and ignoreFilter didn't have the correct behavior when `dirNameRoutePrefix` was altered...
So I used the real file path relative to the root dir.

⚠️ There were a problem with windows with the backslashes. I considered using [unjs/pathe](https://www.npmjs.com/package/pathe), but I felt like this was not necessary to add a package for such a tiny usecase. So I simply used a `replaceAll`, tell me if that's okay.

I also update the test routes responses to `{[name of route]: "[name of the route]"}` for better readability.
I can revert that if you prefer the old way.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
