### PR TITLE
refactor(index): convert unused capture groups to non-capture groups 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Autoload can be customised using the following options:
   ```js
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'plugins'),
-    ignorePattern: /.*(test|spec).js/
+    ignorePattern: /^.*(?:test|spec).js$/
   })
   ```
 
@@ -144,7 +144,7 @@ Autoload can be customised using the following options:
   ```js
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'plugins'),
-    indexPattern: /.*routes(\.ts|\.js|\.cjs|\.mjs)$/
+    indexPattern: /^.*routes(?:\.ts|\.js|\.cjs|\.mjs)$/
   })
   ```
 
@@ -228,7 +228,7 @@ Autoload can be customised using the following options:
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'plugins'),
     autoHooks: true,
-    autoHooksPattern: /^[_.]?auto_?hooks(\.js|\.cjs|\.mjs)$/i
+    autoHooksPattern: /^[_.]?auto_?hooks(?:\.js|\.cjs|\.mjs)$/i
   })
   ```
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ const routeParamPattern = /\/_/ig
 const routeMixedParamPattern = /__/g
 
 const defaults = {
-  scriptPattern: /((^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
-  indexPattern: /^index(\.ts|\.js|\.cjs|\.mjs)$/i,
-  autoHooksPattern: /^[_.]?auto_?hooks(\.ts|\.js|\.cjs|\.mjs)$/i,
+  scriptPattern: /(?:(?:^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
+  indexPattern: /^index(?:\.ts|\.js|\.cjs|\.mjs)$/i,
+  autoHooksPattern: /^[_.]?auto_?hooks(?:\.ts|\.js|\.cjs|\.mjs)$/i,
   dirNameRoutePrefix: true,
   encapsulate: true
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -53,7 +53,7 @@ const opt7: AutoloadPluginOptions = {
   dir: 'test',
   forceESM: true,
   autoHooks: true,
-  autoHooksPattern: /^[_.]?auto_?hooks(\.js|\.cjs|\.mjs)$/i,
+  autoHooksPattern: /^[_.]?auto_?hooks(?:\.ts|\.js|\.cjs|\.mjs)$/i,
   cascadeHooks: true,
   overwriteHooks: true,
 }


### PR DESCRIPTION
- Changed capture groups `(...)` to non-capture groups `(?:...)`, as nothing is done with the captured text in this plugin
- Added `^` to beginning of patterns in the documentation examples starting with `.*`, as ReDoS checkers flag these as vulnerable
- Slapped a closing `$` on the one example in the documentation without it

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
