### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const path = require('path')
-const url = require('url')
-const { readdir } = require('fs').promises
+const path = require('node:path')
+const url = require('node:url')
+const { readdir } = require('node:fs').promises
 const pkgUp = require('pkg-up')
 
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV

--- a/scripts/unit-typescript-esbuild.js
+++ b/scripts/unit-typescript-esbuild.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'node',

--- a/scripts/unit-typescript-esm.js
+++ b/scripts/unit-typescript-esm.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'tap',

--- a/scripts/unit-typescript-swc-node-register.js
+++ b/scripts/unit-typescript-swc-node-register.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'tap',

--- a/scripts/unit-typescript-swc.js
+++ b/scripts/unit-typescript-swc.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'tap',

--- a/scripts/unit-typescript-tsm.js
+++ b/scripts/unit-typescript-tsm.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'tap',

--- a/scripts/unit-typescript-tsx.js
+++ b/scripts/unit-typescript-tsx.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const args = [
   'npx',

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { exec } = require('node:child_process')
 
 const child = exec('npm run unit:with-modules')
 

--- a/test/commonjs/autohooks/basic.js
+++ b/test/commonjs/autohooks/basic.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/autohooks/cascade.js
+++ b/test/commonjs/autohooks/cascade.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/autohooks/disabled.js
+++ b/test/commonjs/autohooks/disabled.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/autohooks/overwrite.js
+++ b/test/commonjs/autohooks/overwrite.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/babel-node.js
+++ b/test/commonjs/babel-node.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 const AutoLoad = require('../../')
-const { join } = require('path')
+const { join } = require('node:path')
 
 t.plan(7)
 

--- a/test/commonjs/basic/app.js
+++ b/test/commonjs/basic/app.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/cyclic-dependency/app.js
+++ b/test/commonjs/cyclic-dependency/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/deep/app.js
+++ b/test/commonjs/deep/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/dependency/app.js
+++ b/test/commonjs/dependency/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const fastifyUrlData = require('@fastify/url-data')
 
 const AutoLoad = require('../../../')

--- a/test/commonjs/graph-dependency/app.js
+++ b/test/commonjs/graph-dependency/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/index-error/app.js
+++ b/test/commonjs/index-error/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/module-error/app.js
+++ b/test/commonjs/module-error/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/non-plugin/app.js
+++ b/test/commonjs/non-plugin/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/options/app.js
+++ b/test/commonjs/options/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const fastifyUrlData = require('@fastify/url-data')
 
 const AutoLoad = require('../../../')

--- a/test/commonjs/route-parameters/basic.js
+++ b/test/commonjs/route-parameters/basic.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/route-parameters/disabled.js
+++ b/test/commonjs/route-parameters/disabled.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/syntax-error/app.js
+++ b/test/commonjs/syntax-error/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {

--- a/test/commonjs/ts-error/app.js
+++ b/test/commonjs/ts-error/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const AutoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
