### PR TITLE
perf(index): convert unused capture group to non-capture group

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,13 @@ const isTsx = process._preload_modules && process._preload_modules.toString().in
 const typescriptSupport = isFastifyAutoloadTypescriptOverride || isTsNode || isVitestEnvironment || isBabelNode || isJestEnvironment || isSWCRegister || isSWCNodeRegister || isSWCNode || isTsm || isTsx || isEsbuildRegister
 
 const forceESMEnvironment = isVitestEnvironment || false
-const routeParamPattern = /\/_/ig
-const routeMixedParamPattern = /__/g
+const routeParamPattern = /\/_/gu
+const routeMixedParamPattern = /__/gu
 
 const defaults = {
-  scriptPattern: /(?:(?:^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/i,
-  indexPattern: /^index(?:\.ts|\.js|\.cjs|\.mjs)$/i,
-  autoHooksPattern: /^[_.]?auto_?hooks(?:\.ts|\.js|\.cjs|\.mjs)$/i,
+  scriptPattern: /(?:(?:^.?|\.[^d]|[^.]d|[^.][^d])\.ts|\.js|\.cjs|\.mjs)$/iu,
+  indexPattern: /^index(?:\.ts|\.js|\.cjs|\.mjs)$/iu,
+  autoHooksPattern: /^[_.]?auto_?hooks(?:\.ts|\.js|\.cjs|\.mjs)$/iu,
   dirNameRoutePrefix: true,
   encapsulate: true
 }
@@ -122,9 +122,9 @@ async function getPackageType (cwd) {
   }
 }
 
-const typescriptPattern = /\.ts$/i
-const modulePattern = /\.mjs$/i
-const commonjsPattern = /\.cjs$/i
+const typescriptPattern = /\.ts$/iu
+const modulePattern = /\.mjs$/iu
+const commonjsPattern = /\.cjs$/iu
 function getScriptType (fname, packageType) {
   return (modulePattern.test(fname) ? 'module' : commonjsPattern.test(fname) ? 'commonjs' : typescriptPattern.test(fname) ? 'typescript' : packageType) || 'commonjs'
 }
@@ -238,7 +238,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
   function accumulatePlugin ({ file, type }) {
     // Replace backward slash to forward slash for consistent behavior between windows and posix.
-    const filePath = '/' + path.relative(options.dir, file).replace(/\\/g, '/')
+    const filePath = '/' + path.relative(options.dir, file).replace(/\\/gu, '/')
 
     if (matchFilter && !filterPath(filePath, matchFilter)) {
       return
@@ -294,7 +294,7 @@ async function loadPlugin ({ file, type, directoryPrefix, options, log }) {
   if (prefixOverride !== undefined) {
     pluginOptions.prefix = prefixOverride
   } else if (prefix) {
-    pluginOptions.prefix = (pluginOptions.prefix || '') + prefix.replace(/\/+/g, '/')
+    pluginOptions.prefix = (pluginOptions.prefix || '') + prefix.replace(/\/+/gu, '/')
   }
 
   return {
@@ -376,7 +376,7 @@ function isPluginOrModule (input) {
   let result = false
 
   const inputType = Object.prototype.toString.call(input)
-  if (/\[object (AsyncFunction|Function|Module)\]/.test(inputType) === true) {
+  if (/\[object (?:AsyncFunction|Function|Module)\]/u.test(inputType) === true) {
     result = true
   } else if (Object.prototype.hasOwnProperty.call(input, 'default')) {
     result = isPluginOrModule(input.default)


### PR DESCRIPTION
- Changed capture group `(...)` to non-capture group `(?:...)`, as nothing is done with the captured text in this plugin, the regex engine is doing extra work capturing text only to end up not using it
- Added the `u` unicode flag to every regex pattern, which [acts as a strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#description) for regex
- Removed a redundant `i` case-insensitive flag from a pattern that had no word characters in it
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
