### PR TITLE
chore: remove `getPackageType` deps, fix for Bun

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,13 +117,13 @@ const fastifyAutoload = async function autoload (fastify, options) {
 async function getPackageType (cwd) {
   const directories = cwd.split(path.sep)
 
-  // required for paths that begin with the sep
-  directories[0] ||= path.sep
+  // required for paths that begin with the sep, such as linux root
+  directories[0] = directories[0] !== '' ? directories[0] : path.sep
 
   while (directories.length > 0) {
     const file = path.join(...directories, 'package.json')
 
-    const fileExists = await fs.access(file, fs.constants.F_OK)
+    const fileExists = await fs.stat(file)
       .then(() => true)
       .catch(() => false)
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const fs = require('node:fs/promises')
-const path = require('node:path')
-const url = require('node:url')
+const { promises: { readdir, readFile } } = require('node:fs')
+const { join, relative, sep } = require('node:path')
+const { pathToFileURL } = require('node:url')
 
 const isFastifyAutoloadTypescriptOverride = !!process.env.FASTIFY_AUTOLOAD_TYPESCRIPT
 const isTsNode = (Symbol.for('ts-node.register.instance') in process) || !!process.env.TS_NODE_DEV
@@ -115,20 +115,19 @@ const fastifyAutoload = async function autoload (fastify, options) {
 }
 
 async function getPackageType (cwd) {
-  const directories = cwd.split(path.sep)
+  const directories = cwd.split(sep)
 
   // required for paths that begin with the sep, such as linux root
-  directories[0] = directories[0] !== '' ? directories[0] : path.sep
+  directories[0] = directories[0] !== '' ? directories[0] : sep
 
   while (directories.length > 0) {
-    const file = path.join(...directories, 'package.json')
+    const filePath = join(...directories, 'package.json')
 
-    const fileExists = await fs.stat(file)
-      .then(() => true)
-      .catch(() => false)
+    const fileContents = await readFile(filePath, 'utf-8')
+      .catch(() => null)
 
-    if (fileExists) {
-      return require(file).type
+    if (fileContents) {
+      return JSON.parse(fileContents).type
     }
 
     directories.pop()
@@ -145,7 +144,7 @@ function getScriptType (fname, packageType) {
 // eslint-disable-next-line default-param-last
 async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth = 0, hooks = []) {
   const { indexPattern, ignorePattern, ignoreFilter, matchFilter, scriptPattern, dirNameRoutePrefix, maxDepth, autoHooksPattern } = options
-  const list = await fs.readdir(dir, { withFileTypes: true })
+  const list = await readdir(dir, { withFileTypes: true })
   let currentHooks = []
 
   // check to see if hooks or plugins have been added to this prefix, initialize if not
@@ -162,7 +161,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
     // Contains autohooks file?
     const autoHooks = list.find((dirent) => autoHooksPattern.test(dirent.name))
     if (autoHooks) {
-      const autoHooksFile = path.join(dir, autoHooks.name)
+      const autoHooksFile = join(dir, autoHooks.name)
       const autoHooksType = getScriptType(autoHooksFile, options.packageType)
 
       // Overwrite current hooks?
@@ -180,7 +179,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
   // Contains index file?
   const indexDirent = list.find((dirent) => indexPattern.test(dirent.name))
   if (indexDirent) {
-    const file = path.join(dir, indexDirent.name)
+    const file = join(dir, indexDirent.name)
     const type = getScriptType(file, options.packageType)
     if (type === 'typescript' && !typescriptSupport) {
       throw new Error(`@fastify/autoload cannot import hooks plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
@@ -208,7 +207,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
     }
 
     const atMaxDepth = Number.isFinite(maxDepth) && maxDepth <= depth
-    const file = path.join(dir, dirent.name)
+    const file = join(dir, dirent.name)
     if (dirent.isDirectory() && !atMaxDepth) {
       let prefixBreadCrumb = (prefix ? `${prefix}/` : '/')
       if (dirNameRoutePrefix === true) {
@@ -251,7 +250,7 @@ async function findPlugins (dir, options, hookedAccumulator = {}, prefix, depth 
 
   function accumulatePlugin ({ file, type }) {
     // Replace backward slash to forward slash for consistent behavior between windows and posix.
-    const filePath = '/' + path.relative(options.dir, file).replace(/\\/gu, '/')
+    const filePath = '/' + relative(options.dir, file).replace(/\\/gu, '/')
 
     if (matchFilter && !filterPath(filePath, matchFilter)) {
       return
@@ -269,7 +268,7 @@ async function loadPlugin ({ file, type, directoryPrefix, options, log }) {
   const { options: overrideConfig, forceESM, encapsulate } = options
   let content
   if (forceESM || type === 'module' || forceESMEnvironment) {
-    content = await import(url.pathToFileURL(file).href)
+    content = await import(pathToFileURL(file).href)
   } else {
     content = require(file)
   }
@@ -413,7 +412,7 @@ async function loadHook (hook, options) {
   if (!hook) return null
   let hookContent
   if (options.forceESM || hook.type === 'module' || forceESMEnvironment) {
-    hookContent = await import(url.pathToFileURL(hook.file).href)
+    hookContent = await import(pathToFileURL(hook.file).href)
   } else {
     hookContent = require(hook.file)
   }

--- a/package.json
+++ b/package.json
@@ -69,9 +69,7 @@
     "vite": "^4.0.0",
     "vitest": "^0.34.1"
   },
-  "dependencies": {
-    "pkg-up": "^3.1.0"
-  },
+  "dependencies": {},
   "standard": {
     "ignore": [
       "test/*/*-error/lib/a.js"


### PR DESCRIPTION
The `getPackageType` function needlessly relied on the `pkg-up` package tree. While unnecessary, it also caused `@fastify/autoload` to not work with Bun.

Have run `lint:fix` and `test` with no issues. All changes are internal and require no documentation changes.

Not sure the other requirements for contributing to Fastify.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
