### PR TITLE
fix: autohooks prefix concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ const fastifyAutoload = async function autoload (fastify, options) {
   const pluginArray = [].concat.apply([], Object.values(pluginTree).map(o => o.plugins))
   const hookArray = [].concat.apply([], Object.values(pluginTree).map(o => o.hooks))
 
+  let rootPrefix = options.options?.prefix ?? ''
+  // when prefix is provided /prefix/ format
+  // it is not good for concat, since most folder prefix start with /
+  if (rootPrefix[rootPrefix.length - 1] === '/') rootPrefix = rootPrefix.slice(0, -1)
+
   await Promise.all(pluginArray.map(({ file, type, prefix }) => {
     return loadPlugin({ file, type, directoryPrefix: prefix, options: opts, log: fastify.log })
       .then((plugin) => {
@@ -85,7 +90,7 @@ const fastifyAutoload = async function autoload (fastify, options) {
       }
 
       fastify.register(composedPlugin, {
-        prefix: options.options?.prefix ?? replaceRouteParamPattern(prefix)
+        prefix: rootPrefix + replaceRouteParamPattern(prefix)
       })
     }
   }

--- a/test/issues/326/test.js
+++ b/test/issues/326/test.js
@@ -62,7 +62,7 @@ app.ready(function (err) {
   })
 
   app.inject({
-    url: '/custom-prefix'
+    url: '/custom-prefix/child'
   }, function (err, res) {
     t.error(err)
 
@@ -70,7 +70,7 @@ app.ready(function (err) {
   })
 
   app.inject({
-    url: '/custom-prefix/not-exists'
+    url: '/custom-prefix/child/not-exists'
   }, function (err, res) {
     t.error(err)
     t.equal(res.headers.from, 'routes-b')

--- a/test/issues/376/routes/entity/.autohooks.js
+++ b/test/issues/376/routes/entity/.autohooks.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = async function (app, opts) {
+  app.addHook('onRequest', async (req, reply) => {
+      req.hooked = req.hooked || []
+      req.hooked.push('root')
+    })
+}

--- a/test/issues/376/routes/entity/index.js
+++ b/test/issues/376/routes/entity/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app, opts, next) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ path: req.url, hooked: req.hooked })
+  })
+}

--- a/test/issues/376/routes/index.js
+++ b/test/issues/376/routes/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app, opts, next) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ path: req.url })
+  })
+}

--- a/test/issues/376/test.js
+++ b/test/issues/376/test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const t = require('tap')
+const path = require('node:path')
+const Fastify = require('fastify')
+const autoLoad = require('../../../')
+
+t.plan(13)
+
+const app = Fastify()
+
+app.register(autoLoad, {
+  dir: path.join(__dirname, 'routes'),
+  autoHooks: true,
+  options: { prefix: '/api' }
+})
+
+app.register(autoLoad, {
+  dir: path.join(__dirname, 'routes'),
+  autoHooks: true,
+  options: { prefix: '/prefix/' }
+})
+
+app.ready(function (err) {
+  t.error(err)
+
+  app.inject({
+    url: '/api'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), { path: '/api' })
+  })
+
+  app.inject({
+    url: '/api/entity'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), { path: '/api/entity', hooked: ['root'] })
+  })
+
+  app.inject({
+    url: '/prefix'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), { path: '/prefix' })
+  })
+
+  app.inject({
+    url: '/prefix/entity'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(res.json(), { path: '/prefix/entity', hooked: ['root'] })
+  })
+})


### PR DESCRIPTION
Since no core member add value to https://github.com/fastify/fastify-autoload/issues/376#issuecomment-2129429693
I want to move things forward to users desire behavior.

Fixes #376 

As mention in last submitted PR, I believe the long term solution is refactor the code to create a single tree that contain both `hook` and `plugin` information.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
