### PR TITLE
Allow `autoConfig` with callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --loader=my-custom-loader index.ts
 
 Each plugin can be individually configured using the following module properties:
 
-- `plugin.autoConfig` - Configuration object which will be used as `opts` parameter
+- `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -330,6 +330,13 @@ Each plugin can be individually configured using the following module properties
     })
   }
   export const autoConfig = { name: 'y' }
+  ```
+
+  You can also use a callback function if you need to access the parent instance:
+  ```js
+  export const autoConfig = (fastify) => {
+    return { name: 'y ' + fastify.rootName }
+  }
   ```
 
 - `plugin.autoPrefix` - Set routing prefix for plugin

--- a/README.md
+++ b/README.md
@@ -339,6 +339,15 @@ Each plugin can be individually configured using the following module properties
   }
   ```
 
+  However, note that the `prefix` option should be set directly on `autoConfig` for autoloading to work as expected:
+  ```js
+  export const autoConfig = (fastify) => {
+    return { name: 'y ' + fastify.rootName }
+  }
+
+  autoConfig.prefix = '/hello'
+  ```
+
 - `plugin.autoPrefix` - Set routing prefix for plugin
 
   ```js

--- a/index.js
+++ b/index.js
@@ -282,7 +282,17 @@ async function loadPlugin ({ file, type, directoryPrefix, options, log }) {
 
   const plugin = wrapRoutes(content.default || content)
   const pluginConfig = (content.default && content.default.autoConfig) || content.autoConfig || {}
-  const pluginOptions = typeof pluginConfig === 'function' ? pluginConfig : Object.assign({}, pluginConfig, overrideConfig)
+  let pluginOptions
+  if (typeof pluginConfig === 'function') {
+    pluginOptions = function (fastify) {
+      return { ...pluginConfig(fastify), ...overrideConfig }
+    }
+
+    pluginOptions.prefix = pluginConfig.prefix
+  } else {
+    pluginOptions = { ...pluginConfig, ...overrideConfig }
+  }
+
   const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
 
   if (!encapsulate) {

--- a/index.js
+++ b/index.js
@@ -288,7 +288,7 @@ async function loadPlugin ({ file, type, directoryPrefix, options, log }) {
       return { ...pluginConfig(fastify), ...overrideConfig }
     }
 
-    pluginOptions.prefix = pluginConfig.prefix
+    pluginOptions.prefix = overrideConfig.prefix ?? pluginConfig.prefix
   } else {
     pluginOptions = { ...pluginConfig, ...overrideConfig }
   }

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ async function loadPlugin ({ file, type, directoryPrefix, options, log }) {
 
   const plugin = wrapRoutes(content.default || content)
   const pluginConfig = (content.default && content.default.autoConfig) || content.autoConfig || {}
-  const pluginOptions = Object.assign({}, pluginConfig, overrideConfig)
+  const pluginOptions = typeof pluginConfig === 'function' ? pluginConfig : Object.assign({}, pluginConfig, overrideConfig)
   const pluginMeta = plugin[Symbol.for('plugin-meta')] || {}
 
   if (!encapsulate) {

--- a/test/commonjs/basic.js
+++ b/test/commonjs/basic.js
@@ -3,7 +3,7 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(101)
+t.plan(107)
 
 const app = Fastify()
 
@@ -269,5 +269,23 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { works: true })
+  })
+
+  app.inject({
+    url: '/configPrefix'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { configPrefix: true })
+  })
+
+  app.inject({
+    url: '/configPrefixCallback'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { configPrefixCallback: true })
   })
 })

--- a/test/commonjs/basic/foo/configPrefix.js
+++ b/test/commonjs/basic/foo/configPrefix.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ configPrefix: true })
+  })
+
+  next()
+}
+
+module.exports.autoConfig = {
+  prefix: '/configPrefix'
+}

--- a/test/commonjs/basic/foo/configPrefixCallback.js
+++ b/test/commonjs/basic/foo/configPrefixCallback.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ configPrefixCallback: true })
+  })
+
+  next()
+}
+
+const options = () => ({})
+options.prefix = '/configPrefixCallback'
+
+module.exports.autoConfig = options

--- a/test/commonjs/options.js
+++ b/test/commonjs/options.js
@@ -3,9 +3,11 @@
 const t = require('tap')
 const Fastify = require('fastify')
 
-t.plan(19)
+t.plan(22)
 
 const app = Fastify()
+
+app.decorate('root', 'root')
 
 app.register(require('./options/app'))
 
@@ -51,6 +53,14 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { data: 'test-3' })
+  })
+
+  app.inject({
+    url: '/plugin-e'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { data: 'test-4-root' })
   })
 
   app.inject({

--- a/test/commonjs/options/plugins/plugin-e.js
+++ b/test/commonjs/options/plugins/plugin-e.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+
+function plugin (f, opts, next) {
+  f.get('/plugin-e', (request, reply) => {
+    reply.send({ data: opts.e })
+  })
+
+  next()
+}
+
+plugin.autoConfig = (fastify) => {
+  return { e: 'test-4-' + fastify.root }
+}
+
+exports.default = fp(plugin, { name: 'plugin-e' })

--- a/test/module/basic.js
+++ b/test/module/basic.js
@@ -2,7 +2,7 @@ import t from 'tap'
 import fastify from 'fastify'
 import basicApp from './basic/app.js'
 
-t.plan(74)
+t.plan(80)
 
 const app = fastify()
 
@@ -226,5 +226,23 @@ app.ready(function (err) {
       error: 'Not Found',
       statusCode: 404
     })
+  })
+
+  app.inject({
+    url: '/configPrefix'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { configPrefix: true })
+  })
+
+  app.inject({
+    url: '/configPrefixCallback'
+  }, function (err, res) {
+    t.error(err)
+
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { configPrefixCallback: true })
   })
 })

--- a/test/module/basic/foo/configPrefix.js
+++ b/test/module/basic/foo/configPrefix.js
@@ -1,0 +1,13 @@
+'use strict'
+
+export default function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ configPrefix: true })
+  })
+
+  next()
+}
+
+export const autoConfig = {
+  prefix: '/configPrefix'
+}

--- a/test/module/basic/foo/configPrefixCallback.js
+++ b/test/module/basic/foo/configPrefixCallback.js
@@ -1,0 +1,12 @@
+'use strict'
+
+export default function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ configPrefixCallback: true })
+  })
+
+  next()
+}
+
+export const autoConfig = () => ({})
+autoConfig.prefix = '/configPrefixCallback'

--- a/test/module/options.js
+++ b/test/module/options.js
@@ -2,9 +2,11 @@ import t from 'tap'
 import fastify from 'fastify'
 import optionsApp from './options/app.js'
 
-t.plan(19)
+t.plan(22)
 
 const app = fastify()
+
+app.decorate('root', 'root')
 
 app.register(optionsApp)
 
@@ -50,6 +52,14 @@ app.ready(function (err) {
     t.error(err)
     t.equal(res.statusCode, 200)
     t.same(JSON.parse(res.payload), { data: 'test-3' })
+  })
+
+  app.inject({
+    url: '/plugin-e'
+  }, function (err, res) {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+    t.same(JSON.parse(res.payload), { data: 'test-4-root' })
   })
 
   app.inject({

--- a/test/module/options/plugins/plugin-e.js
+++ b/test/module/options/plugins/plugin-e.js
@@ -1,0 +1,14 @@
+import fp from 'fastify-plugin'
+
+function plugin (f, opts, next) {
+  f.get('/plugin-e', (request, reply) => {
+    reply.send({ data: opts.e })
+  })
+
+  next()
+}
+
+export default fp(plugin, { name: 'plugin-e' })
+export const autoConfig = (fastify) => {
+  return { e: 'test-4-' + fastify.root }
+}


### PR DESCRIPTION
Can be usefull to autoload plugins:
```js
import fastifyMysql from "@fastify/mysql";

export const autoConfig = (fastify) => {
  return {
    promise: true,
    host: fastify.config.MYSQL_HOST,
    user: fastify.config.MYSQL_USER,
    password: fastify.config.MYSQL_PASSWORD,
    database: fastify.config.MYSQL_DATABASE,
    port: Number(fastify.config.MYSQL_PORT)
  }
}

export default fastifyMysql
```