### PR TITLE
fix: check require.cache to find preloaded modules

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const path = require('path')
+
 // runtime cache
 const cache = {}
 
@@ -14,11 +16,16 @@ function checkProcessArgv (moduleName) {
 
 let preloadModules
 function checkPreloadModules (moduleName) {
+  const modulePath = path.join(process.cwd(), 'node_modules/', moduleName)
+
   /* c8 ignore start */
-  // nullish needed for non Node.js runtime
+  // coverage - nullish needed for non Node.js runtime
   preloadModules ??= (process._preload_modules ?? [])
+
+  // coverage - TS specific
+  return preloadModules.includes(moduleName) ||
+    Object.keys(require.cache).some(k => k.startsWith(modulePath) && preloadModules.push(modulePath))
   /* c8 ignore stop */
-  return preloadModules.includes(moduleName)
 }
 
 let preloadModulesString

--- a/runtime.js
+++ b/runtime.js
@@ -16,8 +16,6 @@ function checkProcessArgv (moduleName) {
 
 let preloadModules
 function checkPreloadModules (moduleName) {
-  const modulePath = path.join(process.cwd(), 'node_modules/', moduleName)
-
   /* c8 ignore start */
   // coverage - nullish needed for non Node.js runtime
   preloadModules ??= (process._preload_modules ?? [])
@@ -27,6 +25,7 @@ function checkPreloadModules (moduleName) {
     return true
   }
 
+  const modulePath = path.join(process.cwd(), 'node_modules/', moduleName)
   if (Object.keys(require.cache).some(k => k.startsWith(modulePath))) {
     preloadModules.push(moduleName)
 

--- a/runtime.js
+++ b/runtime.js
@@ -23,9 +23,18 @@ function checkPreloadModules (moduleName) {
   preloadModules ??= (process._preload_modules ?? [])
 
   // coverage - TS specific
-  return preloadModules.includes(moduleName) ||
-    Object.keys(require.cache).some(k => k.startsWith(modulePath) && preloadModules.push(modulePath))
+  if (preloadModules.includes(moduleName)) {
+    return true
+  }
+
+  if (Object.keys(require.cache).some(k => k.startsWith(modulePath))) {
+    preloadModules.push(moduleName)
+
+    return true
+  }
   /* c8 ignore stop */
+
+  return false
 }
 
 let preloadModulesString

--- a/runtime.js
+++ b/runtime.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 
 // runtime cache
 const cache = {}
@@ -18,7 +18,7 @@ let preloadModules
 function checkPreloadModules (moduleName) {
   /* c8 ignore start */
   // coverage - nullish needed for non Node.js runtime
-  preloadModules ??= (process._preload_modules ?? [])
+  preloadModules ??= [...(process._preload_modules ?? [])]
 
   // coverage - TS specific
   if (preloadModules.includes(moduleName)) {
@@ -26,7 +26,7 @@ function checkPreloadModules (moduleName) {
   }
 
   const modulePath = path.join(process.cwd(), 'node_modules', moduleName)
-  if (Object.keys(require.cache).some(k => k.startsWith(modulePath))) {
+  if (Object.keys(require.cache).some((k) => k.startsWith(modulePath))) {
     preloadModules.push(moduleName)
 
     return true

--- a/runtime.js
+++ b/runtime.js
@@ -25,7 +25,7 @@ function checkPreloadModules (moduleName) {
     return true
   }
 
-  const modulePath = path.join(process.cwd(), 'node_modules/', moduleName)
+  const modulePath = path.join(process.cwd(), 'node_modules', moduleName)
   if (Object.keys(require.cache).some(k => k.startsWith(modulePath))) {
     preloadModules.push(moduleName)
 


### PR DESCRIPTION
Fixes #404 

I tested on the reproduction repo and it does work well: https://github.com/zetaraku/fastify-app