### PR TITLE
feat: Add Bun and Deno to typescript support check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,28 @@ jobs:
     with:
       license-check: true
       lint: true
+  bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        # The erraneous typod version `5.0.0-aplha` takes priority over .3 as 'p' > 'l'
+        run: |
+          bun i --ignore-scripts
+          bun i -D --ignore-scripts fastify@5.0.0-alpha.3
+
+      - name: Run types check
+        run: bun run typescript
+
+      - name: Run Jest tests
+        run: bun run typescript:jest
+
+      - name: Run Vitest tests
+        run: bun run typescript:vitest
+
+      - name: Run unit tests
+        run: bun run unit:bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,11 @@ jobs:
       lint: true
   bun:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         # The erraneous typod version `5.0.0-aplha` takes priority over .3 as 'p' > 'l'
         run: |
           bun i --ignore-scripts
-          bun i -D --ignore-scripts fastify@5.0.0-alpha.3
+          bun i -D --ignore-scripts fastify@5.0.0-alpha.4
 
       - name: Run types check
         run: bun run typescript

--- a/lib/find-plugins.js
+++ b/lib/find-plugins.js
@@ -145,7 +145,10 @@ function accumulatePlugin ({ file, type, opts, pluginTree, prefix }) {
 
 function handleTypeScriptSupport (file, language, isHook = false) {
   if (language === 'typescript' && !runtime.supportTypeScript) {
-    throw new Error(`@fastify/autoload cannot import ${isHook ? 'hooks ' : ''}plugin at '${file}'. To fix this error compile TypeScript to JavaScript or use 'ts-node' to run your app.`)
+    throw new Error(
+      `@fastify/autoload cannot import ${isHook ? 'hooks ' : ''}plugin at '${file}'. ` +
+      'To fix this error transpile TypeScript to JavaScript or use an alternative loader/runtime to run your app.'
+    )
   }
 }
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -33,6 +33,14 @@ function checkEnvVariable (name, value) {
     : process.env[name] !== undefined
 }
 
+function isBun () {
+  return 'Bun' in globalThis
+}
+
+function isDeno () {
+  return 'Deno' in globalThis
+}
+
 const runtime = {}
 // use Object.defineProperties to provide lazy load
 Object.defineProperties(runtime, {
@@ -102,6 +110,8 @@ Object.defineProperties(runtime, {
     get () {
       cache.supportTypeScript ??= (
         checkEnvVariable('FASTIFY_AUTOLOAD_TYPESCRIPT') ||
+        isBun() ||
+        isDeno() ||
         runtime.tsNode ||
         runtime.vitest ||
         runtime.babelNode ||

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript:esbuild": "node scripts/unit-typescript-esbuild.js",
     "typescript:vitest": "vitest run",
     "typescript:vitest:dev": "vitest",
-    "unit": "node scripts/unit.js npm",
+    "unit": "node scripts/unit.js",
     "unit:bun": "node scripts/unit.js bun",
     "unit:with-modules": "tap plugin rm @tapjs/typescript && tap plugin list && tap build && tap test/issues/*/test.js test/commonjs/*.js test/module/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/tap": "^15.0.11",
     "esbuild": "^0.23.0",
     "esbuild-register": "^3.5.0",
-    "fastify": "^5.0.0-alpha.3",
+    "fastify": "^5.0.0-alpha.4",
     "fastify-plugin": "^5.0.0-pre.fv5.1",
     "jest": "^29.7.0",
     "snazzy": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "typescript:esbuild": "node scripts/unit-typescript-esbuild.js",
     "typescript:vitest": "vitest run",
     "typescript:vitest:dev": "vitest",
-    "unit": "node scripts/unit.js",
+    "unit": "node scripts/unit.js npm",
+    "unit:bun": "node scripts/unit.js bun",
     "unit:with-modules": "tap plugin rm @tapjs/typescript && tap plugin list && tap build && tap test/issues/*/test.js test/commonjs/*.js test/module/*.js"
   },
   "repository": {

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -3,7 +3,7 @@
 const { exec } = require('node:child_process')
 const { argv } = require('node:process')
 
-const child = exec(argv[2] + ' run unit:with-modules')
+const child = exec((argv[2] ?? 'npm') + ' run unit:with-modules')
 
 child.stdout.pipe(process.stdout)
 child.stderr.pipe(process.stderr)

--- a/scripts/unit.js
+++ b/scripts/unit.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const { exec } = require('node:child_process')
+const { argv } = require('node:process')
 
-const child = exec('npm run unit:with-modules')
+const child = exec(argv[2] + ' run unit:with-modules')
 
 child.stdout.pipe(process.stdout)
 child.stderr.pipe(process.stderr)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This change allows the Bun and Deno runtimes to use this loader with Fastify base without erroring as seen in #317.

### Tests

#### Node

No regressions, everything passing.

#### Bun

- `bun run typescript` ✅
- `bun run typescript:jest` ✅
- `bun run typescript:vitest` ✅
- `bun run unit` ✅
  - `unit.js` updated to consume an arg for the runtime
- The bun equivalent of the loader tests that execute `test/typescript/basic.ts` cannot be run as a particular function Tap uses has not yet been implemented in Bun
  - `NotImplementedError: node:v8 Serializer is not yet implemented in Bun.`

#### Deno

- `deno task typescript` ✅
- Deno implements `ServerResponse` as a class, while node a function, which causes this error in Fastify.
  - `Class constructor ServerResponse cannot be invoked without 'new'`
  - This causes the following to fail
    - `deno task typescript:jest` ❌
    - `deno task typescript:vitest` ❌
    - `deno task unit` ❌


While it has already been communicated that Fastify is not actively supporting either Bun or Deno runtimes, despite the results, it would be great to see this check updated to allow their usage at a "ymmv" degree.

Fixes #317 

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [x] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


