### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ or with ESM syntax:
 
 ```js
 import autoLoad from '@fastify/autoload'
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import fastify from 'fastify'
 
 const __filename = fileURLToPath(import.meta.url)

--- a/test/module/autohooks/basic.mjs
+++ b/test/module/autohooks/basic.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/module/autohooks/cascade.mjs
+++ b/test/module/autohooks/cascade.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/module/autohooks/disabled.mjs
+++ b/test/module/autohooks/disabled.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/module/autohooks/overwrite.mjs
+++ b/test/module/autohooks/overwrite.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/module/basic/app.js
+++ b/test/module/basic/app.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
-import path, { dirname } from 'path'
+import fs from 'node:fs'
+import path, { dirname } from 'node:path'
 import autoLoad from '../../../index.js'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/test/module/dependency/app.js
+++ b/test/module/dependency/app.js
@@ -1,7 +1,7 @@
-import path, { dirname } from 'path'
+import path, { dirname } from 'node:path'
 import fastifyUrlData from '@fastify/url-data'
 import autoLoad from '../../../index.js'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/test/module/esm-import/app-default.js
+++ b/test/module/esm-import/app-default.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import fastifyAutoloadDefault from '../../../index.js'
 

--- a/test/module/esm-import/app-named.js
+++ b/test/module/esm-import/app-named.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { fastifyAutoload as fastifyAutoloadNamed } from '../../../index.js'
 

--- a/test/module/esm-import/app-star-default.js
+++ b/test/module/esm-import/app-star-default.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import * as fastifyAutoloadStar from '../../../index.js'
 

--- a/test/module/esm-import/app-star-named.js
+++ b/test/module/esm-import/app-star-named.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import * as fastifyAutoloadStar from '../../../index.js'
 

--- a/test/module/index-package/app.js
+++ b/test/module/index-package/app.js
@@ -1,5 +1,5 @@
-import url from 'url'
-import path from 'path'
+import url from 'node:url'
+import path from 'node:path'
 import fastifyAutoload from '../../../index.js'
 
 export default function (fastify, opts, next) {

--- a/test/module/index-package/index.js
+++ b/test/module/index-package/index.js
@@ -1,5 +1,5 @@
-import url from 'url'
-import process from 'process'
+import url from 'node:url'
+import process from 'node:process'
 
 if (url.fileURLToPath(import.meta.url) === process.argv[1]) {
   // side effects

--- a/test/module/options/app.js
+++ b/test/module/options/app.js
@@ -1,6 +1,6 @@
-import path from 'path'
+import path from 'node:path'
 import fastifyUrlData from '@fastify/url-data'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import autoLoad from '../../../index.js'
 
 const { dirname } = path

--- a/test/module/route-parameters/basic.mjs
+++ b/test/module/route-parameters/basic.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/module/route-parameters/disabled.mjs
+++ b/test/module/route-parameters/disabled.mjs
@@ -1,5 +1,5 @@
-import path from 'path'
-import { fileURLToPath } from 'url'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import autoload from '../../../index.js'
 

--- a/test/typescript-esm/forceESM.ts
+++ b/test/typescript-esm/forceESM.ts
@@ -1,6 +1,6 @@
 import fastify from 'fastify'
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import t from 'tap'
 import fastifyAutoLoad from '../../'
 

--- a/test/typescript-jest/babel-node/index.test.ts
+++ b/test/typescript-jest/babel-node/index.test.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify'
-import { join } from 'path'
+import { join } from 'node:path'
 import AutoLoad from '../../../'
 
 describe('load typescript using babel-node', () => {

--- a/test/typescript-jest/basic/app.ts
+++ b/test/typescript-jest/basic/app.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from 'fastify'
-import { join } from 'path'
+import { join } from 'node:path'
 const fastifyAutoLoad = require('../../../index')
 
 const app: FastifyPluginCallback = function (fastify, opts, next): void {

--- a/test/typescript-jest/integration/integration.test.ts
+++ b/test/typescript-jest/integration/integration.test.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { exec } from 'node:child_process'
 
 describe('integration test', function () {
   test.concurrent.each(['ts-node', 'ts-node-dev'])(

--- a/test/typescript/basic/app.ts
+++ b/test/typescript/basic/app.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginCallback } from 'fastify'
-import { join } from 'path'
+import { join } from 'node:path'
 import fastifyAutoLoad from '../../../'
 
 const app: FastifyPluginCallback = function (fastify, opts, next): void {

--- a/test/vitest/basic.test.ts
+++ b/test/vitest/basic.test.ts
@@ -3,7 +3,7 @@
 import { describe, test, expect } from 'vitest'
 import Fastify from 'fastify'
 import AutoLoad from '../../index'
-import { join } from 'path'
+import { join } from 'node:path'
 
 describe.concurrent('Vitest test suite', function () {
   const app = Fastify()

--- a/test/vitest/filter.test.ts
+++ b/test/vitest/filter.test.ts
@@ -3,7 +3,7 @@
 import { describe, test, expect } from 'vitest'
 import Fastify from 'fastify'
 import AutoLoad from '../../index'
-import { join } from 'path'
+import { join } from 'node:path'
 
 describe.concurrent('Vitest ignore filters test suite', function () {
   const app = Fastify()


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407. This is a batch PR, so may have some issues. Please review changes.