### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/tap": "^18.0.0",
     "esbuild": "^0.24.0",
     "esbuild-register": "^3.5.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "fastify-plugin": "^5.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.