### PR TITLE
refactor: leverage process.features.typescript instead of node version

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -124,7 +124,7 @@ Object.defineProperties(runtime, {
   },
   supportNativeTypeScript: {
     get () {
-      cache.supportNativeTypeScript ??= ['strip', 'transform'].includes(process.features.typescript)
+      cache.supportNativeTypeScript ??= process.features.typescript !== undefined && process.features.typescript !== false
       return cache.supportNativeTypeScript
     }
   },

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -124,7 +124,7 @@ Object.defineProperties(runtime, {
   },
   supportNativeTypeScript: {
     get () {
-      cache.supportNativeTypeScript ??= process.features.typescript !== false
+      cache.supportNativeTypeScript ??= ['strip', 'transform'].includes(process.features.typescript)
       return cache.supportNativeTypeScript
     }
   },

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -117,9 +117,15 @@ Object.defineProperties(runtime, {
         runtime.tsx ||
         runtime.esbuild ||
         runtime.tsimp ||
-        runtime.nodeVersion >= 23
+        runtime.supportNativeTypeScript
       )
       return cache.supportTypeScript
+    }
+  },
+  supportNativeTypeScript: {
+    get () {
+      cache.supportNativeTypeScript ??= process.features.typescript !== false
+      return cache.supportNativeTypeScript
     }
   },
   forceESM: {
@@ -131,12 +137,6 @@ Object.defineProperties(runtime, {
       )
       return cache.forceESM
     }
-  },
-  nodeVersion: {
-    get () {
-      cache.nodeVersion ??= Number(process.version.split('.')[0].slice(1))
-      return cache.nodeVersion
-    },
   },
 })
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -124,7 +124,10 @@ Object.defineProperties(runtime, {
   },
   supportNativeTypeScript: {
     get () {
-      cache.supportNativeTypeScript ??= process.features.typescript !== undefined && process.features.typescript !== false
+      cache.supportNativeTypeScript ??=
+      /* c8 ignore start - The right-hand part of the branch is unreachable on v20 for the moment */
+      process.features.typescript !== undefined && process.features.typescript !== false
+      /* c8 ignore end */
       return cache.supportNativeTypeScript
     }
   },

--- a/scripts/unit-typescript-native-type-stripping.js
+++ b/scripts/unit-typescript-native-type-stripping.js
@@ -3,6 +3,10 @@
 const { exec } = require('node:child_process')
 const runtime = require('../lib/runtime')
 
+if (runtime.supportNativeTypeScript) {
+  common()
+}
+
 function common () {
   const args = ['node', 'test/typescript-common/index.ts']
   const child = exec(args.join(' '), {
@@ -23,8 +27,4 @@ function esm () {
   child.stdout.pipe(process.stdout)
   child.stderr.pipe(process.stderr)
   child.once('close', process.exit)
-}
-
-if (runtime.nodeVersion >= 23) {
-  common()
 }

--- a/scripts/unit-typescript-tsx.js
+++ b/scripts/unit-typescript-tsx.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const { exec } = require('node:child_process')
-const runtime = require('../lib/runtime')
+
+const nodeVersion = Number(process.version.split('.')[0].slice(1))
 
 const args = [
   'npx',
-  runtime.nodeVersion >= 18 ? '--node-options=--import=tsx' : '',
+  nodeVersion >= 18 ? '--node-options=--import=tsx' : '',
   'tsnd',
   'test/typescript/basic.ts'
 ]

--- a/test/commonjs/error.js
+++ b/test/commonjs/error.js
@@ -6,8 +6,6 @@ const Fastify = require('fastify')
 
 const runtime = require('../../lib/runtime')
 
-const typeStrippingEnabled = runtime.nodeVersion >= 23
-
 describe('independent module support - unexpected token', function () {
   const app = Fastify()
 
@@ -52,7 +50,7 @@ describe('independent module support - cannot import plugin typescript', functio
   })
 
   it('should return cannot import plugin typescript error', async function () {
-    if (typeStrippingEnabled) {
+    if (runtime.supportNativeTypeScript) {
       assert.doesNotThrow(() => app.ready())
     } else {
       await assert.rejects(app.ready(), Error, /cannot import plugin.*typescript/i)

--- a/test/issues/369/test.js
+++ b/test/issues/369/test.js
@@ -24,7 +24,7 @@ describe('Issue 369 tests', async function () {
       dir: path.join(__dirname, 'invalid-index-type'),
       autoHooks: true,
     })
-    if (runtime.nodeVersion >= 23) {
+    if (runtime.supportNativeTypeScript) {
       assert.doesNotThrow(() => app.ready())
     } else {
       await assert.rejects(

--- a/test/typescript-common/index.ts
+++ b/test/typescript-common/index.ts
@@ -1,6 +1,6 @@
 'use script'
 
-const t = require('tap')
+const { test: t } = require('node:test')
 const fastify = require('fastify')
 
 const basicApp = require('./basic/app.ts')


### PR DESCRIPTION
Node version is not reliable enough to guess typescript support, but we can leverage `process.features.typescript`.

https://github.com/fastify/fastify-cli/pull/798#issuecomment-2708361175