### PR TITLE
Resolve dirNameRoutePrefix interferes with auto-hooks

### DIFF
--- a/lib/find-plugins.js
+++ b/lib/find-plugins.js
@@ -8,7 +8,7 @@ async function findPlugins (dir, options) {
   const { opts, prefix } = options
 
   const pluginTree = {
-    [prefix || '/']: { hooks: [], plugins: [] }
+    [dir]: { hooks: [], plugins: [] }
   }
 
   await buildTree(pluginTree, dir, { prefix, opts, depth: 0, hooks: [] })
@@ -18,8 +18,8 @@ async function findPlugins (dir, options) {
 
 async function buildTree (pluginTree, dir, { prefix, opts, depth, hooks }) {
   // check to see if hooks or plugins have been added to this prefix, initialize if not
-  if (!pluginTree[prefix]) {
-    pluginTree[prefix] = { hooks: [], plugins: [] }
+  if (!pluginTree[dir]) {
+    pluginTree[dir] = { hooks: [], plugins: [] }
   }
 
   const dirEntries = await readdir(dir, { withFileTypes: true })
@@ -47,6 +47,7 @@ function findCurrentDirHooks (pluginTree, { dir, dirEntries, hooks, opts, prefix
   let currentDirHooks = []
   // Hooks were passed in, create new array specific to this plugin item
   for (const hook of hooks) {
+    console.log(hook)
     currentDirHooks.push(hook)
   }
 
@@ -65,7 +66,7 @@ function findCurrentDirHooks (pluginTree, { dir, dirEntries, hooks, opts, prefix
     currentDirHooks.push({ file, type })
   }
 
-  pluginTree[prefix || '/'].hooks = currentDirHooks
+  pluginTree[dir].hooks = currentDirHooks
 
   return currentDirHooks
 }
@@ -78,7 +79,7 @@ function processIndexDirEntryIfExists (pluginTree, { opts, dirEntries, dir, pref
   const file = join(dir, indexDirEntry.name)
   const { language, type } = getScriptType(file, opts.packageType)
   handleTypeScriptSupport(file, language, true)
-  accumulatePlugin({ file, type, opts, pluginTree, prefix })
+  accumulatePlugin({ dir, file, type, opts, pluginTree, prefix })
 
   const hasNoDirectory = dirEntries.every((dirEntry) => !dirEntry.isDirectory())
 
@@ -98,7 +99,7 @@ async function processDirContents (pluginTree, { dirEntries, opts, indexDirEntry
     } else if (indexDirEntry) {
       // An index.js file is present in the directory so we ignore the others modules (but not the subdirectories)
     } else if (dirEntry.isFile() && opts.scriptPattern.test(dirEntry.name)) {
-      processFile(pluginTree, { file, opts, dirEntry, pluginTree, prefix })
+      processFile(pluginTree, { dir, file, opts, dirEntry, pluginTree, prefix })
     }
   }
 }
@@ -119,17 +120,17 @@ async function processDirectory (pluginTree, { prefix, opts, dirEntry, dir, file
   await buildTree(pluginTree, file, { opts, prefix: prefixBreadCrumb, depth: depth + 1, hooks })
 }
 
-function processFile (pluginTree, { file, opts, dirEntry, prefix }) {
+function processFile (pluginTree, { dir, file, opts, dirEntry, prefix }) {
   const { language, type } = getScriptType(file, opts.packageType)
   handleTypeScriptSupport(file, language)
 
   // Don't place hook in plugin queue
   if (!opts.autoHooksPattern.test(dirEntry.name)) {
-    accumulatePlugin({ file, type, opts, pluginTree, prefix })
+    accumulatePlugin({ dir, file, type, opts, pluginTree, prefix })
   }
 }
 
-function accumulatePlugin ({ file, type, opts, pluginTree, prefix }) {
+function accumulatePlugin ({ dir, file, type, opts, pluginTree, prefix }) {
   // Replace backward slash to forward slash for consistent behavior between windows and posix.
   const filePath = '/' + relative(opts.dir, file).replace(/\\/gu, '/')
   if (opts.matchFilter && !filterPath(filePath, opts.matchFilter)) {
@@ -140,7 +141,7 @@ function accumulatePlugin ({ file, type, opts, pluginTree, prefix }) {
     return
   }
 
-  pluginTree[prefix || '/'].plugins.push({ file, type, prefix })
+  pluginTree[dir].plugins.push({ file, type, prefix })
 }
 
 function handleTypeScriptSupport (file, language, isHook = false) {

--- a/lib/find-plugins.js
+++ b/lib/find-plugins.js
@@ -47,7 +47,6 @@ function findCurrentDirHooks (pluginTree, { dir, dirEntries, hooks, opts, prefix
   let currentDirHooks = []
   // Hooks were passed in, create new array specific to this plugin item
   for (const hook of hooks) {
-    console.log(hook)
     currentDirHooks.push(hook)
   }
 

--- a/lib/find-plugins.js
+++ b/lib/find-plugins.js
@@ -24,7 +24,7 @@ async function buildTree (pluginTree, dir, { prefix, opts, depth, hooks }) {
 
   const dirEntries = await readdir(dir, { withFileTypes: true })
 
-  const currentDirHooks = findCurrentDirHooks(pluginTree, { dir, dirEntries, hooks, opts, prefix })
+  const currentDirHooks = findCurrentDirHooks(pluginTree, { dir, dirEntries, hooks, opts })
 
   const { indexDirEntry, hasNoDirectory } = processIndexDirEntryIfExists(pluginTree, { dirEntries, opts, dir, prefix })
   if (hasNoDirectory) {
@@ -41,7 +41,7 @@ async function buildTree (pluginTree, dir, { prefix, opts, depth, hooks }) {
   await processDirContents(pluginTree, { dirEntries, opts, indexDirEntry, prefix, dir, depth, currentDirHooks })
 }
 
-function findCurrentDirHooks (pluginTree, { dir, dirEntries, hooks, opts, prefix }) {
+function findCurrentDirHooks (pluginTree, { dir, dirEntries, hooks, opts }) {
   if (!opts.autoHooks) return []
 
   let currentDirHooks = []

--- a/test/issues/453/routes/autohooks.mjs
+++ b/test/issues/453/routes/autohooks.mjs
@@ -1,0 +1,7 @@
+const pluginRegister = async (fastify) => {
+  fastify.addHook('onRequest', async (request) => {
+    request.hooksUsed.push('global')
+  })
+}
+
+export default pluginRegister

--- a/test/issues/453/routes/first/autohooks.mjs
+++ b/test/issues/453/routes/first/autohooks.mjs
@@ -1,0 +1,7 @@
+const pluginRegister = async (fastify) => {
+  fastify.addHook('onRequest', async (request) => {
+    request.hooksUsed.push('first')
+  })
+}
+
+export default pluginRegister

--- a/test/issues/453/routes/first/first.route.mjs
+++ b/test/issues/453/routes/first/first.route.mjs
@@ -1,0 +1,7 @@
+const routes = async (fastify) => {
+  fastify.get('/first', async (request) => {
+    return { hooksUsed: request.hooksUsed }
+  })
+}
+
+export default routes

--- a/test/issues/453/routes/first/fourth/autohooks.mjs
+++ b/test/issues/453/routes/first/fourth/autohooks.mjs
@@ -1,0 +1,7 @@
+const pluginRegister = async (fastify) => {
+  fastify.addHook('onRequest', async (request) => {
+    request.hooksUsed.push('fourth')
+  })
+}
+
+export default pluginRegister

--- a/test/issues/453/routes/first/fourth/fourth.route.mjs
+++ b/test/issues/453/routes/first/fourth/fourth.route.mjs
@@ -1,0 +1,7 @@
+const routes = async (fastify) => {
+  fastify.get('/fourth', async (request) => {
+    return { hooksUsed: request.hooksUsed }
+  })
+}
+
+export default routes

--- a/test/issues/453/routes/global.route.mjs
+++ b/test/issues/453/routes/global.route.mjs
@@ -1,0 +1,7 @@
+const routes = async (fastify) => {
+  fastify.get('/global', async (request) => {
+    return { hooksUsed: request.hooksUsed }
+  })
+}
+
+export default routes

--- a/test/issues/453/routes/second/autohooks.mjs
+++ b/test/issues/453/routes/second/autohooks.mjs
@@ -1,3 +1,5 @@
+// This folder is not used directly by the test, but in the previous implementation, the last hook used would affect the outcome.
+// This folder ensures that the test fails if the fix is reverted or modified incorrectly.
 const pluginRegister = async (fastify) => {
   fastify.addHook('onRequest', async (request) => {
     request.hooksUsed.push('second')

--- a/test/issues/453/routes/second/autohooks.mjs
+++ b/test/issues/453/routes/second/autohooks.mjs
@@ -1,0 +1,7 @@
+const pluginRegister = async (fastify) => {
+  fastify.addHook('onRequest', async (request) => {
+    request.hooksUsed.push('second')
+  })
+}
+
+export default pluginRegister

--- a/test/issues/453/routes/second/second.route.mjs
+++ b/test/issues/453/routes/second/second.route.mjs
@@ -1,0 +1,7 @@
+const routes = async (fastify) => {
+  fastify.get('/second', async (request) => {
+    return { hooksUsed: request.hooksUsed }
+  })
+}
+
+export default routes

--- a/test/issues/453/routes/second/second.route.mjs
+++ b/test/issues/453/routes/second/second.route.mjs
@@ -1,3 +1,5 @@
+// This folder is not used directly by the test, but in the previous implementation, the last hook used would affect the outcome.
+// This folder ensures that the test fails if the fix is reverted or modified incorrectly.
 const routes = async (fastify) => {
   fastify.get('/second', async (request) => {
     return { hooksUsed: request.hooksUsed }

--- a/test/issues/453/test.js
+++ b/test/issues/453/test.js
@@ -1,0 +1,226 @@
+'use strict'
+
+const { beforeEach, afterEach, describe, it } = require('node:test')
+const assert = require('node:assert')
+const path = require('node:path')
+const Fastify = require('fastify')
+const autoLoad = require('../../../')
+
+const startApp = async (autoloadConfig) => {
+  const app = Fastify()
+  app.addHook('onRequest', async (request) => {
+    request.hooksUsed = []
+  })
+  app.register(autoLoad, {
+    dir: path.join(__dirname, 'routes'),
+    autoHooks: true,
+    ...autoloadConfig,
+  })
+  app.decorateRequest('hooksUsed')
+  await app.ready()
+  return app
+}
+
+describe('Issue 453 tests', function () {
+  describe('cascadeHooks === false', () => {
+    describe('dirNameRoutePrefix === true not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: false,
+          dirNameRoutePrefix: true
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should only use child hook in child route', async function () {
+        const res = await app.inject({ url: '/first/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['first'] })
+      })
+
+      it('should only use grandchild hook in grandchild route', async function () {
+        const res = await app.inject({ url: '/first/fourth/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['fourth'] })
+      })
+    })
+    describe('dirNameRoutePrefix === false not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: false,
+          dirNameRoutePrefix: false
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should only use child hook in child route', async function () {
+        const res = await app.inject({ url: '/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['first'] })
+      })
+
+      it('should only use grandchild hook in grandchild route', async function () {
+        const res = await app.inject({ url: '/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['fourth'] })
+      })
+    })
+    describe('dirNameRoutePrefix === () => false not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: false,
+          dirNameRoutePrefix: () => {
+            return false
+          }
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should only use child hook in child route', async function () {
+        const res = await app.inject({ url: '/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['first'] })
+      })
+
+      it('should only use grandchild hook in grandchild route', async function () {
+        const res = await app.inject({ url: '/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['fourth'] })
+      })
+    })
+  })
+
+  describe('cascadeHooks === true', () => {
+    describe('dirNameRoutePrefix === true not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: true,
+          dirNameRoutePrefix: true
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should use hooks till child in child route', async function () {
+        const res = await app.inject({ url: '/first/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first'] })
+      })
+
+      it('should use hooks till grandchild in grandchild route', async function () {
+        const res = await app.inject({ url: '/first/fourth/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first', 'fourth'] })
+      })
+    })
+    describe('dirNameRoutePrefix === false not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: true,
+          dirNameRoutePrefix: false
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should use hooks till child in child route', async function () {
+        const res = await app.inject({ url: '/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first'] })
+      })
+
+      it('should use hooks till grandchild in grandchild route', async function () {
+        const res = await app.inject({ url: '/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first', 'fourth'] })
+      })
+    })
+    describe('dirNameRoutePrefix === () => false not interfere with auto hooks', () => {
+      let app
+
+      beforeEach(async function () {
+        app = await startApp({
+          cascadeHooks: true,
+          dirNameRoutePrefix: () => {
+            return false
+          }
+        })
+      })
+
+      afterEach(async function () {
+        await app.close()
+      })
+
+      it('should only use global hook in global route', async function () {
+        const res = await app.inject({ url: '/global' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global'] })
+      })
+
+      it('should use hooks till child in child route', async function () {
+        const res = await app.inject({ url: '/first' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first'] })
+      })
+
+      it('should use hooks till grandchild in grandchild route', async function () {
+        const res = await app.inject({ url: '/fourth' })
+        assert.strictEqual(res.statusCode, 200)
+        assert.deepStrictEqual(JSON.parse(res.body), { hooksUsed: ['global', 'first', 'fourth'] })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Should resolve https://github.com/fastify/fastify-autoload/issues/453

Previously the prefix from `dirNameRoutePrefix` was used as a key to build the plugins which resulted in an unexpected behaviour.
For example with:
```
fastify.register(pluginAutoload, {
  autoHooks: true,
  cascadeHooks: true,
  // ISSUE: The parent folder routes and the first-level child routes will inherit the last registered hook (e.g., third.hook.mjs).
  dirNameRoutePrefix: false,
})
```
The routes in the parent folder were using the child folder hooks and if you have multiple child folder in the parent folder all of them would be using the last registered hook [see the issue](https://github.com/fastify/fastify-autoload/issues/453).

I tested this in my reproduction [repository](https://github.com/MrWook/reproduction-fastify-autoload-hook-issue) and it seems to be working as expected now.