### PR TITLE
docs(readme): use h3 headers for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Folder structure:
 
 Autoload can be customized using the following options:
 
-#### `dir` (required) - Base directory containing plugins to be loaded
+### `dir` (required) - Base directory containing plugins to be loaded
 
   Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In which case, only the index file (and the potential sub-directories) will be loaded.
 
@@ -101,7 +101,7 @@ Autoload can be customized using the following options:
   - `.mjs` (ES modules)
   - `.ts` (TypeScript)
 
-#### `dirNameRoutePrefix` (optional) - Default: true. Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
+### `dirNameRoutePrefix` (optional) - Default: true. Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
 
   ```js
   fastify.register(autoLoad, {
@@ -123,7 +123,7 @@ Autoload can be customized using the following options:
   })
   ```
 
-#### `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
+### `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -133,7 +133,7 @@ Autoload can be customized using the following options:
   ```
 
 
-#### `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
+### `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -143,7 +143,7 @@ Autoload can be customized using the following options:
   ```
 
 
-#### `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
+### `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
 
   ```js
   fastify.register(autoLoad, {
@@ -153,7 +153,7 @@ Autoload can be customized using the following options:
   ```
 
 
-#### `scriptPattern` (optional) - Regex to override the script files accepted by default. You should only use this option
+### `scriptPattern` (optional) - Regex to override the script files accepted by default. You should only use this option
 with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)
 provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
 
@@ -165,7 +165,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `indexPattern` (optional) - Regex to override the `index.js` naming convention
+### `indexPattern` (optional) - Regex to override the `index.js` naming convention
 
   ```js
   fastify.register(autoLoad, {
@@ -174,7 +174,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
+### `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
 
   ```js
   fastify.register(autoLoad, {
@@ -183,7 +183,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
+### `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
 
   ```js
   fastify.register(autoLoad, {
@@ -191,7 +191,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
     forceESM: true
   })
   ```
-#### `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
+### `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
 
   ```js
   fastify.register(autoLoad, {
@@ -200,7 +200,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `options` (optional) - Global options object used for all registered plugins
+### `options` (optional) - Global options object used for all registered plugins
 
   Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
 
@@ -234,7 +234,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   // routes can now be added to /defaultPrefix/something
   ```
 
-#### `autoHooks` (optional) - Apply hooks from `autohooks.js` file(s) to plugins found in folder
+### `autoHooks` (optional) - Apply hooks from `autohooks.js` file(s) to plugins found in folder
 
   Automatic hooks from `autohooks` files will be encapsulated with plugins. If `false`, all `autohooks.js` files will be ignored.
 
@@ -248,7 +248,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
   and decorated values _will not be exported_ outside the folder.
 
-#### `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
+### `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
 
   ```js
   fastify.register(autoLoad, {
@@ -258,7 +258,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `cascadeHooks` (optional) - If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
+### `cascadeHooks` (optional) - If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
 
   Default behavior of `autoHooks` is to apply hooks only to the level on which the `autohooks.js` file is found. Setting `cascadeHooks: true` will continue applying the hooks to any children.
 
@@ -270,7 +270,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `overwriteHooks` (optional) - If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
+### `overwriteHooks` (optional) - If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
 
   Default behavior of `cascadeHooks` is to accumulate hooks as new `autohooks.js` files are discovered and cascade to children. Setting `overwriteHooks: true` will start a new hook cascade when new `autohooks.js` files are encountered.
 
@@ -283,7 +283,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-#### `routeParams` (optional) - Folders prefixed with `_` will be turned into dynamic route parameters.
+### `routeParams` (optional) - Folders prefixed with `_` will be turned into dynamic route parameters.
 
   If you want to use mixed route parameters use a double underscore `__`.
 
@@ -335,7 +335,7 @@ FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --loader=my-custom-loader index.ts
 
 Each plugin can be individually configured using the following module properties:
 
-#### `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
+### `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -375,7 +375,7 @@ Each plugin can be individually configured using the following module properties
   autoConfig.prefix = '/hello'
   ```
 
-#### `plugin.autoPrefix` - Set routing prefix for plugin
+### `plugin.autoPrefix` - Set routing prefix for plugin
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -404,7 +404,7 @@ Each plugin can be individually configured using the following module properties
   ```
 
 
-#### `plugin.prefixOverride` - Override all other prefix options
+### `plugin.prefixOverride` - Override all other prefix options
 
   ```js
   // index.js
@@ -453,7 +453,7 @@ Each plugin can be individually configured using the following module properties
   // routes can now be added without a prefix
   ```
 
-#### `plugin.autoload` - Toggle whether the plugin should be loaded
+### `plugin.autoload` - Toggle whether the plugin should be loaded
 
   Example:
 
@@ -466,9 +466,9 @@ Each plugin can be individually configured using the following module properties
   module.exports.autoload = false
   ```
 
-#### `opts.name` - Set name of plugin so that it can be referenced as a dependency
+### `opts.name` - Set name of plugin so that it can be referenced as a dependency
 
-#### `opts.dependencies` - Set plugin dependencies to ensure correct load order
+### `opts.dependencies` - Set plugin dependencies to ensure correct load order
 
   Example:
 

--- a/README.md
+++ b/README.md
@@ -92,261 +92,261 @@ Autoload can be customized using the following options:
 
 ### `dir` (required)
 
-  Base directory containing plugins to be loaded.
+Base directory containing plugins to be loaded.
 
-  Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In which case, only the index file (and the potential sub-directories) will be loaded.
+Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In which case, only the index file (and the potential sub-directories) will be loaded.
 
-  The following script types are supported:
+The following script types are supported:
 
-  - `.js ` (CommonJS or ES modules depending on `type` field of parent `package.json`)
-  - `.cjs` (CommonJS)
-  - `.mjs` (ES modules)
-  - `.ts` (TypeScript)
+- `.js ` (CommonJS or ES modules depending on `type` field of parent `package.json`)
+- `.cjs` (CommonJS)
+- `.mjs` (ES modules)
+- `.ts` (TypeScript)
 
 ### `dirNameRoutePrefix` (optional) - Default: `true`
 
 Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'routes'),
-    dirNameRoutePrefix: false // lack of prefix will mean no prefix, instead of directory name
-  })
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'routes'),
+  dirNameRoutePrefix: false // lack of prefix will mean no prefix, instead of directory name
+})
 
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'routes'),
-    dirNameRoutePrefix: function rewrite (folderParent, folderName) {
-      if (folderName === 'YELLOW') {
-        return 'yellow-submarine'
-      }
-      if (folderName === 'FoOoO-BaAaR') {
-        return false
-      }
-      return folderName
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'routes'),
+  dirNameRoutePrefix: function rewrite (folderParent, folderName) {
+    if (folderName === 'YELLOW') {
+      return 'yellow-submarine'
     }
-  })
-  ```
+    if (folderName === 'FoOoO-BaAaR') {
+      return false
+    }
+    return folderName
+  }
+})
+```
 
 ### `matchFilter` (optional)
 
-  Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
+Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    matchFilter: (path) => path.split("/").at(-2) === "handlers"
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  matchFilter: (path) => path.split("/").at(-2) === "handlers"
+})
+```
 
 
 ### `ignoreFilter` (optional)
 
-  Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
+Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    ignoreFilter: (path) => path.endsWith('.spec.js')
-  })
-  ```
-
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  ignoreFilter: (path) => path.endsWith('.spec.js')
+})
+```
 
 ### `ignorePattern` (optional)
-  
-  RegExp matching any file or folder that should not be loaded.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    ignorePattern: /^.*(?:test|spec).js$/
-  })
-  ```
+RegExp matching any file or folder that should not be loaded.
 
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  ignorePattern: /^.*(?:test|spec).js$/
+})
+```
 
 ### `scriptPattern` (optional)
 
-  Regex to override the script files accepted by default. You should only use this option with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
+Regex to override the script files accepted by default. You should only use this option with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
 
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    scriptPattern: /(?<!\.d)\.(ts|tsx)$/
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  scriptPattern: /(?<!\.d)\.(ts|tsx)$/
+})
+```
 
 ### `indexPattern` (optional)
 
-  Regex to override the `index.js` naming convention.
+Regex to override the `index.js` naming convention.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    indexPattern: /^.*routes(?:\.ts|\.js|\.cjs|\.mjs)$/
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  indexPattern: /^.*routes(?:\.ts|\.js|\.cjs|\.mjs)$/
+})
+```
 
 ### `maxDepth` (optional)
 
-  Limits the depth at which nested plugins are loaded.
+Limits the depth at which nested plugins are loaded.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    maxDepth: 2 // files in `opts.dir` nested more than 2 directories deep will be ignored.
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  maxDepth: 2 // files in `opts.dir` nested more than 2 directories deep will be ignored.
+})
+```
 
 ### `forceESM` (optional)
 
-  If set to 'true' it always use `await import` to load plugins or hooks.
+If set to 'true' it always use `await import` to load plugins or hooks.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    forceESM: true
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  forceESM: true
+})
+```
+
 ### `encapsulate` (optional) - Default: `true`
 
-  If set to `false` each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
+If set to `false` each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    encapsulate: false
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  encapsulate: false
+})
+```
 
 ### `options` (optional)
 
-  Global options object used for all registered plugins.
+Global options object used for all registered plugins.
 
-  Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
+Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
 
-  When setting both `options.prefix` and `plugin.autoPrefix` they will be concatenated.
+When setting both `options.prefix` and `plugin.autoPrefix` they will be concatenated.
 
-  ```js
-  // index.js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    options: { prefix: '/defaultPrefix' }
+```js
+// index.js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  options: { prefix: '/defaultPrefix' }
+})
+
+// /plugins/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
+
+module.exports.autoPrefix = '/something'
+
+// /plugins/something.mjs
+export default function (f, opts, next) {
+  f.get('/', (request, reply) => {
+    reply.send({ something: 'else' })
   })
 
-  // /plugins/something.js
-  module.exports = function (fastify, opts, next) {
-    // your plugin
-  }
+  next()
+}
 
-  module.exports.autoPrefix = '/something'
+export const autoPrefix = '/prefixed'
 
-  // /plugins/something.mjs
-  export default function (f, opts, next) {
-    f.get('/', (request, reply) => {
-      reply.send({ something: 'else' })
-    })
-
-    next()
-  }
-
-  export const autoPrefix = '/prefixed'
-
-  // routes can now be added to /defaultPrefix/something
-  ```
+// routes can now be added to /defaultPrefix/something
+```
 
 ### `autoHooks` (optional)
-  
-  Apply hooks from `autohooks.js` file(s) to plugins found in folder.
 
-  Automatic hooks from `autohooks` files will be encapsulated with plugins. If `false`, all `autohooks.js` files will be ignored.
+Apply hooks from `autohooks.js` file(s) to plugins found in folder.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    autoHooks: true // apply hooks to routes in this level
-  })
-  ```
+Automatic hooks from `autohooks` files will be encapsulated with plugins. If `false`, all `autohooks.js` files will be ignored.
 
-  If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
-  and decorated values _will not be exported_ outside the folder.
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  autoHooks: true // apply hooks to routes in this level
+})
+```
+
+If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
+and decorated values _will not be exported_ outside the folder.
 
 ### `autoHooksPattern` (optional)
 
-  Regex to override the `autohooks` naming convention.
+Regex to override the `autohooks` naming convention.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    autoHooks: true,
-    autoHooksPattern: /^[_.]?auto_?hooks(?:\.js|\.cjs|\.mjs)$/i
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  autoHooks: true,
+  autoHooksPattern: /^[_.]?auto_?hooks(?:\.js|\.cjs|\.mjs)$/i
+})
+```
 
 ### `cascadeHooks` (optional)
 
-  If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
+If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
 
-  Default behavior of `autoHooks` is to apply hooks only to the level on which the `autohooks.js` file is found. Setting `cascadeHooks: true` will continue applying the hooks to any children.
+Default behavior of `autoHooks` is to apply hooks only to the level on which the `autohooks.js` file is found. Setting `cascadeHooks: true` will continue applying the hooks to any children.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    autoHooks: true, // apply hooks to routes in this level,
-    cascadeHooks: true // continue applying hooks to children, starting at this level
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  autoHooks: true, // apply hooks to routes in this level,
+  cascadeHooks: true // continue applying hooks to children, starting at this level
+})
+```
 
 ### `overwriteHooks` (optional) 
 
-  If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
+If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
 
-  Default behavior of `cascadeHooks` is to accumulate hooks as new `autohooks.js` files are discovered and cascade to children. Setting `overwriteHooks: true` will start a new hook cascade when new `autohooks.js` files are encountered.
+Default behavior of `cascadeHooks` is to accumulate hooks as new `autohooks.js` files are discovered and cascade to children. Setting `overwriteHooks: true` will start a new hook cascade when new `autohooks.js` files are encountered.
 
-  ```js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    autoHooks: true, // apply hooks to routes in this level,
-    cascadeHooks: true, // continue applying hooks to children, starting at this level,
-    overwriteHooks: true // re-start hook cascade when a new `autohooks.js` file is found
-  })
-  ```
+```js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  autoHooks: true, // apply hooks to routes in this level,
+  cascadeHooks: true, // continue applying hooks to children, starting at this level,
+  overwriteHooks: true // re-start hook cascade when a new `autohooks.js` file is found
+})
+```
 
 ### `routeParams` (optional) 
 
-  Folders prefixed with `_` will be turned into dynamic route parameters. If you want to use mixed route parameters use a double underscore `__`.
+Folders prefixed with `_` will be turned into dynamic route parameters. If you want to use mixed route parameters use a double underscore `__`.
 
-  ```js
-  /*
-  ├── routes
-  ├── __country-__language
-  │   │  └── actions.js
-  │   └── users
-  │       ├── _id
-  │       │   └── actions.js
-  │       ├── __country-__language
-  │       │   └── actions.js
-  │       └── index.js
-  └── app.js
-  */
+```js
+/*
+├── routes
+├── __country-__language
+│   │  └── actions.js
+│   └── users
+│       ├── _id
+│       │   └── actions.js
+│       ├── __country-__language
+│       │   └── actions.js
+│       └── index.js
+└── app.js
+*/
 
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'routes'),
-    routeParams: true
-    // routes/users/_id/actions.js will be loaded with prefix /users/:id
-    // routes/__country-__language/actions.js will be loaded with prefix /:country-:language
-  })
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'routes'),
+  routeParams: true
+  // routes/users/_id/actions.js will be loaded with prefix /users/:id
+  // routes/__country-__language/actions.js will be loaded with prefix /:country-:language
+})
 
-  // curl http://localhost:3000/users/index
-  // { userIndex: [ { id: 7, username: 'example' } ] }
+// curl http://localhost:3000/users/index
+// { userIndex: [ { id: 7, username: 'example' } ] }
 
-  // curl http://localhost:3000/users/7/details
-  // { user: { id: 7, username: 'example' } }
+// curl http://localhost:3000/users/7/details
+// { user: { id: 7, username: 'example' } }
 
-  // curl http://localhost:3000/be-nl
-  // { country: 'be', language: 'nl' }
-  ```
+// curl http://localhost:3000/be-nl
+// { country: 'be', language: 'nl' }
+```
 
 ## Override TypeScript detection using an environment variable
+
 This plugin uses [native type stripping](https://nodejs.org/docs/latest-v23.x/api/typescript.html#modules-typescript) with Node 23 and later.
 
 It is possible to override the automatic detection of a TypeScript-capable runtime using the `FASTIFY_AUTOLOAD_TYPESCRIPT` environment variable. If set to a truthy value Autoload will load `.ts` files, expecting that node has a TypeScript-capable loader.
@@ -365,270 +365,269 @@ Each plugin can be individually configured using the following module properties
 
 ### `plugin.autoConfig`
 
-  Specifies the options to be used as the `opts` parameter.
+Specifies the options to be used as the `opts` parameter.
 
-  ```js
-  module.exports = function (fastify, opts, next) {
-    console.log(opts.foo) // 'bar'
-    next()
-  }
+```js
+module.exports = function (fastify, opts, next) {
+  console.log(opts.foo) // 'bar'
+  next()
+}
 
-  module.exports.autoConfig = { foo: 'bar' }
-  ```
+module.exports.autoConfig = { foo: 'bar' }
+```
 
-  Or with ESM syntax:
+Or with ESM syntax:
 
-  ```js
-  import plugin from '../lib-plugin.js'
+```js
+import plugin from '../lib-plugin.js'
 
-  export default async function myPlugin (app, options) {
-    app.get('/', async (request, reply) => {
-      return { hello: options.name }
-    })
-  }
-  export const autoConfig = { name: 'y' }
-  ```
+export default async function myPlugin (app, options) {
+  app.get('/', async (request, reply) => {
+    return { hello: options.name }
+  })
+}
+export const autoConfig = { name: 'y' }
+```
 
-  You can also use a callback function if you need to access the parent instance:
-  ```js
-  export const autoConfig = (fastify) => {
-    return { name: 'y ' + fastify.rootName }
-  }
-  ```
+You can also use a callback function if you need to access the parent instance:
+```js
+export const autoConfig = (fastify) => {
+  return { name: 'y ' + fastify.rootName }
+}
+```
 
-  However, note that the `prefix` option should be set directly on `autoConfig` for autoloading to work as expected:
-  ```js
-  export const autoConfig = (fastify) => {
-    return { name: 'y ' + fastify.rootName }
-  }
+However, note that the `prefix` option should be set directly on `autoConfig` for autoloading to work as expected:
+```js
+export const autoConfig = (fastify) => {
+  return { name: 'y ' + fastify.rootName }
+}
 
-  autoConfig.prefix = '/hello'
-  ```
+autoConfig.prefix = '/hello'
+```
 
 ### `plugin.autoPrefix`
 
-  Set routing prefix for plugin.
+Set routing prefix for plugin.
 
-  ```js
-  module.exports = function (fastify, opts, next) {
-    fastify.get('/', (request, reply) => {
-      reply.send({ hello: 'world' })
-    })
+```js
+module.exports = function (fastify, opts, next) {
+  fastify.get('/', (request, reply) => {
+    reply.send({ hello: 'world' })
+  })
 
-    next()
-  }
+  next()
+}
 
-  module.exports.autoPrefix = '/something'
+module.exports.autoPrefix = '/something'
 
-  // when loaded with autoload, this will be exposed as /something
-  ```
+// when loaded with autoload, this will be exposed as /something
+```
 
-  Or with ESM syntax:
+Or with ESM syntax:
 
-  ```js
-  export default async function (app, opts) {
-    app.get('/', (request, reply) => {
-      return { something: 'else' }
-    })
-  }
+```js
+export default async function (app, opts) {
+  app.get('/', (request, reply) => {
+    return { something: 'else' }
+  })
+}
 
-  export const autoPrefix = '/prefixed'
-  ```
-
+export const autoPrefix = '/prefixed'
+```
 
 ### `plugin.prefixOverride`
 
-  Override all other prefix options.
+Override all other prefix options.
 
-  ```js
-  // index.js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    options: { prefix: '/defaultPrefix' }
-  })
+```js
+// index.js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  options: { prefix: '/defaultPrefix' }
+})
 
-  // /foo/something.js
-  module.exports = function (fastify, opts, next) {
-    // your plugin
-  }
+// /foo/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
 
-  module.exports.prefixOverride = '/overriddenPrefix'
+module.exports.prefixOverride = '/overriddenPrefix'
 
-  // this will be exposed as /overriddenPrefix
-  ```
+// this will be exposed as /overriddenPrefix
+```
 
-  Or with ESM syntax:
+Or with ESM syntax:
 
-  ```js
-  export default async function (app, opts) {
-    // your plugin
-  }
+```js
+export default async function (app, opts) {
+  // your plugin
+}
 
-  export const prefixOverride = '/overriddenPrefix'
-  ```
+export const prefixOverride = '/overriddenPrefix'
+```
 
-  If you have a plugin in the folder you do not want any prefix applied to, you can set `prefixOverride = ''`:
+If you have a plugin in the folder you do not want any prefix applied to, you can set `prefixOverride = ''`:
 
-  ```js
-  // index.js
-  fastify.register(autoLoad, {
-    dir: path.join(__dirname, 'plugins'),
-    options: { prefix: '/defaultPrefix' }
-  })
+```js
+// index.js
+fastify.register(autoLoad, {
+  dir: path.join(__dirname, 'plugins'),
+  options: { prefix: '/defaultPrefix' }
+})
 
-  // /foo/something.js
-  module.exports = function (fastify, opts, next) {
-    // your plugin
-  }
+// /foo/something.js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
 
-  // optional
-  module.exports.prefixOverride = ''
+// optional
+module.exports.prefixOverride = ''
 
-  // routes can now be added without a prefix
-  ```
+// routes can now be added without a prefix
+```
 
 ### `plugin.autoload`
 
-  Toggle whether the plugin should be loaded.
+Toggle whether the plugin should be loaded.
 
-  Example:
+Example:
 
-  ```js
-  module.exports = function (fastify, opts, next) {
-    // your plugin
-  }
+```js
+module.exports = function (fastify, opts, next) {
+  // your plugin
+}
 
-  // optional
-  module.exports.autoload = false
-  ```
+// optional
+module.exports.autoload = false
+```
 
 ### `opts.name`
 
-  Set name of plugin so that it can be referenced as a dependency.
+Set name of plugin so that it can be referenced as a dependency.
 
 ### `opts.dependencies`
 
-  Set plugin dependencies to ensure correct load order.
+Set plugin dependencies to ensure correct load order.
 
-  Example:
+Example:
 
-  ```js
-  // plugins/plugin-a.js
-  const fp = require('fastify-plugin')
+```js
+// plugins/plugin-a.js
+const fp = require('fastify-plugin')
 
-  function plugin (fastify, opts, next) {
-    // plugin a
-  }
+function plugin (fastify, opts, next) {
+  // plugin a
+}
 
-  module.exports = fp(plugin, {
-    name: 'plugin-a',
-    dependencies: ['plugin-b']
+module.exports = fp(plugin, {
+  name: 'plugin-a',
+  dependencies: ['plugin-b']
+})
+
+// plugins/plugin-b.js
+function plugin (fastify, opts, next) {
+  // plugin b
+}
+
+module.exports = fp(plugin, {
+  name: 'plugin-b'
+})
+```
+
+## Autohooks:
+
+The autohooks functionality provides several options for automatically adding hooks, decorators, etc. to your routes. CJS and ESM `autohook` formats are supported.
+
+The default behavior of `autoHooks: true` is to encapsulate the `autohooks.js` plugin with the contents of the folder containing the file. The `cascadeHooks: true` option encapsulates the hooks with the current folder contents and all subsequent children, with any additional `autohooks.js` files being applied cumulatively. The `overwriteHooks: true` option will restart the cascade any time an `autohooks.js` file is encountered.
+
+Plugins and hooks are encapsulated together by folder and registered on the `fastify` instance that loaded the `@fastify/autoload` plugin. For more information on how encapsulation works in Fastify, see: https://fastify.dev/docs/latest/Reference/Encapsulation/#encapsulation
+
+### Example:
+
+```
+├── plugins
+│   ├── hooked-plugin
+│   │   ├── autohooks.js // req.hookOne = 'yes' # CJS syntax
+│   │   ├── routes.js
+│   │   └── children
+│   │       ├── old-routes.js
+│   │       ├── new-routes.js
+│   │       └── grandchildren
+│   │           ├── autohooks.mjs // req.hookTwo = 'yes' # ESM syntax
+│   │           └── routes.mjs
+│   └── standard-plugin
+│       └── routes.js
+└── app.js
+```
+
+```js
+// hooked-plugin/autohooks.js
+
+module.exports = async function (app, opts) {
+  app.addHook('onRequest', async (req, reply) => {
+    req.hookOne = yes;
+  });
+}
+
+// hooked-plugin/children/grandchildren/autohooks.mjs
+
+export default async function (app, opts) {
+  app.addHook('onRequest', async (req, reply) => {
+    req.hookTwo = yes
   })
+}
+```
 
-  // plugins/plugin-b.js
-  function plugin (fastify, opts, next) {
-    // plugin b
-  }
+```bash
+# app.js { autoHooks: true }
 
-  module.exports = fp(plugin, {
-    name: 'plugin-b'
-  })
-  ```
+$ curl http://localhost:3000/standard-plugin/
+{} # no hooks in this folder, so behavior is unchanged
 
-  ## Autohooks:
+$ curl http://localhost:3000/hooked-plugin/
+{ hookOne: 'yes' }
 
-  The autohooks functionality provides several options for automatically adding hooks, decorators, etc. to your routes. CJS and ESM `autohook` formats are supported.
+$ curl http://localhost:3000/hooked-plugin/children/old
+{}
 
-  The default behavior of `autoHooks: true` is to encapsulate the `autohooks.js` plugin with the contents of the folder containing the file. The `cascadeHooks: true` option encapsulates the hooks with the current folder contents and all subsequent children, with any additional `autohooks.js` files being applied cumulatively. The `overwriteHooks: true` option will restart the cascade any time an `autohooks.js` file is encountered.
+$ curl http://localhost:3000/hooked-plugin/children/new
+{}
 
-  Plugins and hooks are encapsulated together by folder and registered on the `fastify` instance that loaded the `@fastify/autoload` plugin. For more information on how encapsulation works in Fastify, see: https://fastify.dev/docs/latest/Reference/Encapsulation/#encapsulation
+$ curl http://localhost:3000/hooked-plugin/children/grandchildren/
+{ hookTwo: 'yes' }
+```
 
-    ### Example:
+```bash
+# app.js { autoHooks: true, cascadeHooks: true }
 
-    ```
-    ├── plugins
-    │   ├── hooked-plugin
-    │   │   ├── autohooks.js // req.hookOne = 'yes' # CJS syntax
-    │   │   ├── routes.js
-    │   │   └── children
-    │   │       ├── old-routes.js
-    │   │       ├── new-routes.js
-    │   │       └── grandchildren
-    │   │           ├── autohooks.mjs // req.hookTwo = 'yes' # ESM syntax
-    │   │           └── routes.mjs
-    │   └── standard-plugin
-    │       └── routes.js
-    └── app.js
-    ```
+$ curl http://localhost:3000/hooked-plugin/
+{ hookOne: 'yes' }
 
-    ```js
-    // hooked-plugin/autohooks.js
+$ curl http://localhost:3000/hooked-plugin/children/old
+{ hookOne: 'yes' }
 
-    module.exports = async function (app, opts) {
-      app.addHook('onRequest', async (req, reply) => {
-        req.hookOne = yes;
-      });
-    }
+$ curl http://localhost:3000/hooked-plugin/children/new
+{ hookOne: 'yes' }
 
-    // hooked-plugin/children/grandchildren/autohooks.mjs
+$ curl http://localhost:3000/hooked-plugin/children/grandchildren/
+{ hookOne: 'yes', hookTwo: 'yes' } # hooks are accumulated and applied in ascending order
+```
 
-    export default async function (app, opts) {
-      app.addHook('onRequest', async (req, reply) => {
-        req.hookTwo = yes
-      })
-    }
-    ```
+```bash
+# app.js { autoHooks: true, cascadeHooks: true, overwriteHooks: true }
 
-    ```bash
-    # app.js { autoHooks: true }
+$ curl http://localhost:3000/hooked-plugin/
+{ hookOne: 'yes' }
 
-    $ curl http://localhost:3000/standard-plugin/
-    {} # no hooks in this folder, so behavior is unchanged
+$ curl http://localhost:3000/hooked-plugin/children/old
+{ hookOne: 'yes' }
 
-    $ curl http://localhost:3000/hooked-plugin/
-    { hookOne: 'yes' }
+$ curl http://localhost:3000/hooked-plugin/children/new
+{ hookOne: 'yes' }
 
-    $ curl http://localhost:3000/hooked-plugin/children/old
-    {}
-
-    $ curl http://localhost:3000/hooked-plugin/children/new
-    {}
-
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
-    { hookTwo: 'yes' }
-    ```
-
-    ```bash
-    # app.js { autoHooks: true, cascadeHooks: true }
-
-    $ curl http://localhost:3000/hooked-plugin/
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/old
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/new
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
-    { hookOne: 'yes', hookTwo: 'yes' } # hooks are accumulated and applied in ascending order
-    ```
-
-    ```bash
-    # app.js { autoHooks: true, cascadeHooks: true, overwriteHooks: true }
-
-    $ curl http://localhost:3000/hooked-plugin/
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/old
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/new
-    { hookOne: 'yes' }
-
-    $ curl http://localhost:3000/hooked-plugin/children/grandchildren/
-    { hookTwo: 'yes' } # new autohooks.js takes over
-    ```
+$ curl http://localhost:3000/hooked-plugin/children/grandchildren/
+{ hookTwo: 'yes' } # new autohooks.js takes over
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Autoload can be customized using the following options:
   - `.mjs` (ES modules)
   - `.ts` (TypeScript)
 
-#### `dirNameRoutePrefix` (optional) - Default: true. Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
-
+#### `dirNameRoutePrefix` (optional) - Default: true. 
+Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
   ```js
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'routes'),

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Folder structure:
 
 Autoload can be customized using the following options:
 
-### `dir` (required) - Base directory containing plugins to be loaded
+### `dir` (required)
+
+  Base directory containing plugins to be loaded.
 
   Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In which case, only the index file (and the potential sub-directories) will be loaded.
 
@@ -101,7 +103,7 @@ Autoload can be customized using the following options:
   - `.mjs` (ES modules)
   - `.ts` (TypeScript)
 
-### `dirNameRoutePrefix` (optional) - Default: true.
+### `dirNameRoutePrefix` (optional) - Default: `true`
 
 Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
 
@@ -125,7 +127,9 @@ Determines whether routes will be automatically prefixed with the subdirectory n
   })
   ```
 
-### `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
+### `matchFilter` (optional)
+
+  Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -135,7 +139,9 @@ Determines whether routes will be automatically prefixed with the subdirectory n
   ```
 
 
-### `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
+### `ignoreFilter` (optional)
+
+  Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -145,7 +151,9 @@ Determines whether routes will be automatically prefixed with the subdirectory n
   ```
 
 
-### `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
+### `ignorePattern` (optional)
+  
+  RegExp matching any file or folder that should not be loaded.
 
   ```js
   fastify.register(autoLoad, {
@@ -155,9 +163,9 @@ Determines whether routes will be automatically prefixed with the subdirectory n
   ```
 
 
-### `scriptPattern` (optional) - Regex to override the script files accepted by default. You should only use this option
-with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)
-provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
+### `scriptPattern` (optional)
+
+  Regex to override the script files accepted by default. You should only use this option with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
 
 
   ```js
@@ -167,7 +175,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `indexPattern` (optional) - Regex to override the `index.js` naming convention
+### `indexPattern` (optional)
+
+  Regex to override the `index.js` naming convention.
 
   ```js
   fastify.register(autoLoad, {
@@ -176,7 +186,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
+### `maxDepth` (optional)
+
+  Limits the depth at which nested plugins are loaded.
 
   ```js
   fastify.register(autoLoad, {
@@ -185,7 +197,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
+### `forceESM` (optional)
+
+  If set to 'true' it always use `await import` to load plugins or hooks.
 
   ```js
   fastify.register(autoLoad, {
@@ -193,7 +207,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
     forceESM: true
   })
   ```
-### `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
+### `encapsulate` (optional) - Default: `true`
+
+  If set to `false` each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
 
   ```js
   fastify.register(autoLoad, {
@@ -202,7 +218,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `options` (optional) - Global options object used for all registered plugins
+### `options` (optional)
+
+  Global options object used for all registered plugins.
 
   Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
 
@@ -236,7 +254,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   // routes can now be added to /defaultPrefix/something
   ```
 
-### `autoHooks` (optional) - Apply hooks from `autohooks.js` file(s) to plugins found in folder
+### `autoHooks` (optional)
+  
+  Apply hooks from `autohooks.js` file(s) to plugins found in folder.
 
   Automatic hooks from `autohooks` files will be encapsulated with plugins. If `false`, all `autohooks.js` files will be ignored.
 
@@ -250,7 +270,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
   and decorated values _will not be exported_ outside the folder.
 
-### `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
+### `autoHooksPattern` (optional)
+
+  Regex to override the `autohooks` naming convention.
 
   ```js
   fastify.register(autoLoad, {
@@ -260,7 +282,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `cascadeHooks` (optional) - If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
+### `cascadeHooks` (optional)
+
+  If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
 
   Default behavior of `autoHooks` is to apply hooks only to the level on which the `autohooks.js` file is found. Setting `cascadeHooks: true` will continue applying the hooks to any children.
 
@@ -272,7 +296,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `overwriteHooks` (optional) - If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
+### `overwriteHooks` (optional) 
+
+  If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
 
   Default behavior of `cascadeHooks` is to accumulate hooks as new `autohooks.js` files are discovered and cascade to children. Setting `overwriteHooks: true` will start a new hook cascade when new `autohooks.js` files are encountered.
 
@@ -285,9 +311,9 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-### `routeParams` (optional) - Folders prefixed with `_` will be turned into dynamic route parameters.
+### `routeParams` (optional) 
 
-  If you want to use mixed route parameters use a double underscore `__`.
+  Folders prefixed with `_` will be turned into dynamic route parameters. If you want to use mixed route parameters use a double underscore `__`.
 
   ```js
   /*
@@ -337,7 +363,9 @@ FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --loader=my-custom-loader index.ts
 
 Each plugin can be individually configured using the following module properties:
 
-### `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
+### `plugin.autoConfig`
+
+  Specifies the options to be used as the `opts` parameter.
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -377,7 +405,9 @@ Each plugin can be individually configured using the following module properties
   autoConfig.prefix = '/hello'
   ```
 
-### `plugin.autoPrefix` - Set routing prefix for plugin
+### `plugin.autoPrefix`
+
+  Set routing prefix for plugin.
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -406,7 +436,9 @@ Each plugin can be individually configured using the following module properties
   ```
 
 
-### `plugin.prefixOverride` - Override all other prefix options
+### `plugin.prefixOverride`
+
+  Override all other prefix options.
 
   ```js
   // index.js
@@ -455,7 +487,9 @@ Each plugin can be individually configured using the following module properties
   // routes can now be added without a prefix
   ```
 
-### `plugin.autoload` - Toggle whether the plugin should be loaded
+### `plugin.autoload`
+
+  Toggle whether the plugin should be loaded.
 
   Example:
 
@@ -468,9 +502,13 @@ Each plugin can be individually configured using the following module properties
   module.exports.autoload = false
   ```
 
-### `opts.name` - Set name of plugin so that it can be referenced as a dependency
+### `opts.name`
 
-### `opts.dependencies` - Set plugin dependencies to ensure correct load order
+  Set name of plugin so that it can be referenced as a dependency.
+
+### `opts.dependencies`
+
+  Set plugin dependencies to ensure correct load order.
 
   Example:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Folder structure:
 
 Autoload can be customized using the following options:
 
-- `dir` (required) - Base directory containing plugins to be loaded
+#### `dir` (required) - Base directory containing plugins to be loaded
 
   Each script file within a directory is treated as a plugin unless the directory contains an index file (e.g. `index.js`). In which case, only the index file (and the potential sub-directories) will be loaded.
 
@@ -101,7 +101,7 @@ Autoload can be customized using the following options:
   - `.mjs` (ES modules)
   - `.ts` (TypeScript)
 
-- `dirNameRoutePrefix` (optional) - Default: true. Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
+#### `dirNameRoutePrefix` (optional) - Default: true. Determines whether routes will be automatically prefixed with the subdirectory name in an autoloaded directory. It can be a sync function that must return a string that will be used as prefix, or it must return `false` to skip the prefix for the directory.
 
   ```js
   fastify.register(autoLoad, {
@@ -123,7 +123,7 @@ Autoload can be customized using the following options:
   })
   ```
 
-- `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
+#### `matchFilter` (optional) - Filter matching any path that should be loaded. Can be a RegExp, a string, or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -133,7 +133,7 @@ Autoload can be customized using the following options:
   ```
 
 
-- `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
+#### `ignoreFilter` (optional) - Filter matching any path that should not be loaded. Can be a RegExp, a string ,or a function returning a boolean.
 
   ```js
   fastify.register(autoLoad, {
@@ -143,7 +143,7 @@ Autoload can be customized using the following options:
   ```
 
 
-- `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
+#### `ignorePattern` (optional) - RegExp matching any file or folder that should not be loaded.
 
   ```js
   fastify.register(autoLoad, {
@@ -153,7 +153,7 @@ Autoload can be customized using the following options:
   ```
 
 
-- `scriptPattern` (optional) - Regex to override the script files accepted by default. You should only use this option
+#### `scriptPattern` (optional) - Regex to override the script files accepted by default. You should only use this option
 with a [customization hooks](https://nodejs.org/docs/latest/api/module.html#customization-hooks)
 provider, such as `ts-node`. Otherwise, widening the acceptance extension here will result in an error.
 
@@ -165,7 +165,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `indexPattern` (optional) - Regex to override the `index.js` naming convention
+#### `indexPattern` (optional) - Regex to override the `index.js` naming convention
 
   ```js
   fastify.register(autoLoad, {
@@ -174,7 +174,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
+#### `maxDepth` (optional) - Limits the depth at which nested plugins are loaded
 
   ```js
   fastify.register(autoLoad, {
@@ -183,7 +183,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
+#### `forceESM` (optional) - If set to 'true' it always use `await import` to load plugins or hooks.
 
   ```js
   fastify.register(autoLoad, {
@@ -191,7 +191,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
     forceESM: true
   })
   ```
-- `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
+#### `encapsulate` (optional) - Defaults to 'true', if set to 'false' each plugin loaded is wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This allows you to share contexts between plugins and the parent context if needed. For example, if you need to share decorators. Read [this](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md#sharing-between-contexts) for more details.
 
   ```js
   fastify.register(autoLoad, {
@@ -200,7 +200,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `options` (optional) - Global options object used for all registered plugins
+#### `options` (optional) - Global options object used for all registered plugins
 
   Any option specified here will override `plugin.autoConfig` options specified in the plugin itself.
 
@@ -234,7 +234,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   // routes can now be added to /defaultPrefix/something
   ```
 
-- `autoHooks` (optional) - Apply hooks from `autohooks.js` file(s) to plugins found in folder
+#### `autoHooks` (optional) - Apply hooks from `autohooks.js` file(s) to plugins found in folder
 
   Automatic hooks from `autohooks` files will be encapsulated with plugins. If `false`, all `autohooks.js` files will be ignored.
 
@@ -248,7 +248,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   If `autoHooks` is set, all plugins in the folder will be [encapsulated](https://github.com/fastify/fastify/blob/main/docs/Reference/Encapsulation.md)
   and decorated values _will not be exported_ outside the folder.
 
-- `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
+#### `autoHooksPattern` (optional) - Regex to override the `autohooks` naming convention
 
   ```js
   fastify.register(autoLoad, {
@@ -258,7 +258,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `cascadeHooks` (optional) - If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
+#### `cascadeHooks` (optional) - If using `autoHooks`, cascade hooks to all children. Ignored if `autoHooks` is `false`.
 
   Default behavior of `autoHooks` is to apply hooks only to the level on which the `autohooks.js` file is found. Setting `cascadeHooks: true` will continue applying the hooks to any children.
 
@@ -270,7 +270,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `overwriteHooks` (optional) - If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
+#### `overwriteHooks` (optional) - If using `cascadeHooks`, cascade will be reset when a new `autohooks.js` file is encountered. Ignored if `autoHooks` is `false`.
 
   Default behavior of `cascadeHooks` is to accumulate hooks as new `autohooks.js` files are discovered and cascade to children. Setting `overwriteHooks: true` will start a new hook cascade when new `autohooks.js` files are encountered.
 
@@ -283,7 +283,7 @@ provider, such as `ts-node`. Otherwise, widening the acceptance extension here w
   })
   ```
 
-- `routeParams` (optional) - Folders prefixed with `_` will be turned into route parameters.
+#### `routeParams` (optional) - Folders prefixed with `_` will be turned into dynamic route parameters.
 
   If you want to use mixed route parameters use a double underscore `__`.
 
@@ -335,7 +335,7 @@ FASTIFY_AUTOLOAD_TYPESCRIPT=1 node --loader=my-custom-loader index.ts
 
 Each plugin can be individually configured using the following module properties:
 
-- `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
+#### `plugin.autoConfig` - Specifies the options to be used as the `opts` parameter.
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -375,7 +375,7 @@ Each plugin can be individually configured using the following module properties
   autoConfig.prefix = '/hello'
   ```
 
-- `plugin.autoPrefix` - Set routing prefix for plugin
+#### `plugin.autoPrefix` - Set routing prefix for plugin
 
   ```js
   module.exports = function (fastify, opts, next) {
@@ -404,7 +404,7 @@ Each plugin can be individually configured using the following module properties
   ```
 
 
-- `plugin.prefixOverride` - Override all other prefix options
+#### `plugin.prefixOverride` - Override all other prefix options
 
   ```js
   // index.js
@@ -453,7 +453,7 @@ Each plugin can be individually configured using the following module properties
   // routes can now be added without a prefix
   ```
 
-- `plugin.autoload` - Toggle whether the plugin should be loaded
+#### `plugin.autoload` - Toggle whether the plugin should be loaded
 
   Example:
 
@@ -466,9 +466,9 @@ Each plugin can be individually configured using the following module properties
   module.exports.autoload = false
   ```
 
-- `opts.name` - Set name of plugin so that it can be referenced as a dependency
+#### `opts.name` - Set name of plugin so that it can be referenced as a dependency
 
-- `opts.dependencies` - Set plugin dependencies to ensure correct load order
+#### `opts.dependencies` - Set plugin dependencies to ensure correct load order
 
   Example:
 


### PR DESCRIPTION
I wasn't able to find the `routeParams` option on the README, I had been searching for "dynamic", "route segment", etc. I opened an issue and was informed of the `routeParams` option.

This PR should help future users search for that option as I did.

@jean-michelet Also suggested that I change the options to use h4 headings instead of plain list entries, so that they can be linked, so I've done that here as well.

Closes #465

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
