### PR TITLE
chore: upgrade dependencie typescript and fix test

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "tsimp": "^2.0.11",
     "tsm": "^2.3.0",
     "tsx": "^4.15.7",
-    "typescript": "5.5",
+    "typescript": "~5.9.3",
     "vite": "^7.0.0",
     "vitest": "^4.0.6"
   },
@@ -108,7 +108,14 @@
       "**/*.test.ts"
     ],
     "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
+      "^.+\\.(ts|tsx)$": [
+        "ts-jest",
+        {
+          "tsconfig": {
+            "esModuleInterop": true
+          }
+        }
+      ]
     }
   },
   "publishConfig": {

--- a/test/typescript-common/index.ts
+++ b/test/typescript-common/index.ts
@@ -1,40 +1,33 @@
-'use script'
+'use strict'
 
-const { test: t } = require('node:test')
+const { test: testRunner } = require('node:test')
+const assert = require('node:assert/strict')
 const fastify = require('fastify')
-
 const basicApp = require('./basic/app.ts')
 
-t.plan(5)
+testRunner('integration test with fastify autoload', async (t: any) => {
+  const app = fastify()
+  app.register(basicApp)
 
-const app = fastify()
+  await app.ready()
 
-app.register(basicApp)
-
-app.ready(async function (err) {
-  t.error(err)
-
-  await app
-    .inject({
+  await t.test('should return javascript data', async () => {
+    const res = await app.inject({
       url: '/javascript',
     })
-    .then(function (res: any) {
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.payload), { script: 'java' })
-    })
-    .catch((err) => {
-      t.error(err)
-    })
 
-  await app
-    .inject({
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(res.json(), { script: 'java' })
+  })
+
+  await t.test('should return typescript data', async () => {
+    const res = await app.inject({
       url: '/typescript',
     })
-    .then(function (res: any) {
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.payload), { script: 'type' })
-    })
-    .catch((err) => {
-      t.error(err)
-    })
+
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(res.json(), { script: 'type' })
+  })
+
+  await app.close()
 })

--- a/test/typescript-jest/integration/instance.ts
+++ b/test/typescript-jest/integration/instance.ts
@@ -7,7 +7,9 @@ app.register(basicApp)
 app.listen({
   port: Math.floor(Math.random() * 3000 + 3000)
 }, function (err) {
-  if (err) process.stderr.write('failed')
+  if (err) {
+    process.stderr.write('failed')
+  }
   process.stdout.write('success')
   app.close()
 })

--- a/test/typescript-jest/integration/integration.test.ts
+++ b/test/typescript-jest/integration/integration.test.ts
@@ -5,7 +5,9 @@ describe('integration test', function () {
     'integration with %s',
     async function (instance) {
       await new Promise(function (resolve) {
-        const child = exec(`${instance} "${process.cwd()}/test/typescript-jest/integration/instance.ts"`)
+        const child = exec(
+          `npx ${instance} --compiler-options '{"module": "commonjs", "moduleResolution": "node", "esModuleInterop": true }' "${process.cwd()}/test/typescript-jest/integration/instance.ts"`
+        )
         let stderr = ''
         child.stderr?.on('data', function (b) {
           stderr = stderr + b.toString()

--- a/test/typescript-jest/integration/integration.test.ts
+++ b/test/typescript-jest/integration/integration.test.ts
@@ -1,13 +1,35 @@
 import { exec } from 'node:child_process'
+import { join } from 'node:path'
 
 describe('integration test', function () {
+  const isWindows = process.platform === 'win32'
+
   test.concurrent.each(['ts-node', 'ts-node-dev'])(
     'integration with %s',
     async function (instance) {
       await new Promise(function (resolve) {
-        const child = exec(
-          `npx ${instance} --compiler-options '{"module": "commonjs", "moduleResolution": "node", "esModuleInterop": true }' "${process.cwd()}/test/typescript-jest/integration/instance.ts"`
+        const compilerOpts = JSON.stringify({
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true
+        })
+
+        const optionsArg = isWindows
+          ? `"${compilerOpts.replace(/"/g, '\\"')}"`
+          : `'${compilerOpts}'`
+
+        const filePath = join(
+          process.cwd(),
+          'test',
+          'typescript-jest',
+          'integration',
+          'instance.ts'
         )
+
+        const child = exec(
+          `npx ${instance} --compiler-options ${optionsArg} "${filePath}"`
+        )
+
         let stderr = ''
         child.stderr?.on('data', function (b) {
           stderr = stderr + b.toString()
@@ -16,6 +38,7 @@ describe('integration test', function () {
         child.stdout?.on('data', function (b) {
           stdout = stdout + b.toString()
         })
+
         child.once('close', function () {
           expect(stderr.includes('failed')).toStrictEqual(false)
           expect(stdout.includes('success')).toStrictEqual(true)
@@ -23,6 +46,6 @@ describe('integration test', function () {
         })
       })
     },
-    30000
+    isWindows ? 60000 : 30000
   )
 })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,9 +1,11 @@
 import fastify, { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import { expectType } from 'tsd'
+// eslint-disable-next-line import-x/no-duplicates
 import * as fastifyAutoloadStar from '..'
 import fastifyAutoloadDefault, { AutoloadPluginOptions, fastifyAutoload as fastifyAutoloadNamed } from '..'
 
-import fastifyAutoloadCjsImport = require('..')
+// eslint-disable-next-line import-x/no-duplicates
+import * as fastifyAutoloadCjsImport from '..'
 const fastifyAutoloadCjs = require('..')
 
 const app: FastifyInstance = fastify()


### PR DESCRIPTION
Proposals:

- Upgrade dependencie `typescript` to `v5.9.3`
- Fixed ES module interoperability warnings by updating import statements
- Changed from `import = require()` syntax to proper ES6 imports to support ECMAScript modules
- Resolved TypeScript error `TS1202` by using namespace imports (`import * as ns from "mod"`) instead of import assignments
- Fixed `Jest` integration tests timeout issues
- Resolved `t.plan is not a function` TypeError in test files

see attached screenshots

This PR should resolve it: https://github.com/fastify/fastify-autoload/pull/478 (dependabot).


<img width="1551" height="493" alt="Screenshot 2026-01-26 alle 12 14 16" src="https://github.com/user-attachments/assets/38a242b1-d79c-4dad-9451-7697db5902e5" />
<img width="1500" height="593" alt="Screenshot 2026-01-26 alle 12 15 20" src="https://github.com/user-attachments/assets/aba1abc2-e823-4f73-be13-bc6004401b11" />
<img width="1433" height="257" alt="Screenshot 2026-01-26 alle 12 13 02" src="https://github.com/user-attachments/assets/bd8ad1e7-b867-4720-836d-ec51f5d05021" />
<img width="1444" height="117" alt="Screenshot 2026-01-26 alle 12 13 47" src="https://github.com/user-attachments/assets/180afee3-0092-453b-b250-c43a49c4f5ea" />



