### PR TITLE
chore: upgrade borp to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@swc/core": "1.15.11",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.3",
-    "borp": "^0.21.0",
+    "borp": "^1.0.0",
     "esbuild": "^0.27.0",
     "esbuild-register": "^3.5.0",
     "eslint": "^9.17.0",


### PR DESCRIPTION
Proposal:

- Upgrade `borp` dependency from `^0.21.0` to `^1.0.0` ( see here: https://github.com/mcollina/borp/releases/tag/v1.0.0 )