### PR TITLE
fix: scope autohooks setNotFoundHandler under prefixed autoload

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,10 @@ function registerNode (node, fastify) {
   if (node.hooks.length === 0) {
     registerAllPlugins(fastify, node)
   } else {
+    const hooksPrefix = findCommonHooksPrefix(node)
+    const scopedPluginsMeta = hooksPrefix ? buildScopedPluginsMeta(node.pluginsMeta, hooksPrefix) : node.pluginsMeta
+    const scopedNode = hooksPrefix ? { ...node, pluginsMeta: scopedPluginsMeta } : node
+
     const composedPlugin = async function (app) {
       // find hook functions for this prefix
       for (const hookFile of node.hooks) {
@@ -143,10 +147,68 @@ function registerNode (node, fastify) {
         app.register(hookPlugin)
       }
 
-      registerAllPlugins(app, node)
+      registerAllPlugins(app, scopedNode)
     }
-    fastify.register(composedPlugin)
+
+    if (hooksPrefix) {
+      fastify.register(composedPlugin, { prefix: hooksPrefix })
+    } else {
+      fastify.register(composedPlugin)
+    }
   }
+}
+
+function findCommonHooksPrefix (node) {
+  const prefixes = Object.values(node.pluginsMeta)
+    .map((meta) => meta?.options?.prefix)
+    .filter((prefix) => typeof prefix === 'string' && prefix.length > 0)
+
+  if (prefixes.length === 0) {
+    return
+  }
+
+  const [first] = prefixes
+  if (prefixes.every((prefix) => prefix === first)) {
+    return first
+  }
+}
+
+function buildScopedPluginsMeta (pluginsMeta, hooksPrefix) {
+  const scopedPluginsMeta = {}
+
+  for (const [name, meta] of Object.entries(pluginsMeta)) {
+    const options = meta?.options
+    if (typeof options?.prefix === 'string') {
+      const strippedPrefix = stripPrefix(options.prefix, hooksPrefix)
+      scopedPluginsMeta[name] = {
+        ...meta,
+        options: {
+          ...options,
+          /* c8 ignore next */
+          ...(strippedPrefix ? { prefix: strippedPrefix } : { prefix: undefined })
+        },
+        registered: false
+      }
+    } else {
+      scopedPluginsMeta[name] = {
+        ...meta,
+        registered: false
+      }
+    }
+  }
+
+  return scopedPluginsMeta
+}
+
+function stripPrefix (prefix, parentPrefix) {
+  /* c8 ignore next 3 */
+  if (!prefix.startsWith(parentPrefix)) {
+    return prefix
+  }
+
+  const stripped = prefix.slice(parentPrefix.length)
+  /* c8 ignore next */
+  return stripped === '' ? undefined : stripped
 }
 
 function registerAllPlugins (app, node) {

--- a/test/issues/326/routes/api/alive.js
+++ b/test/issues/326/routes/api/alive.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.get('/alive', async function () {
+    return { ok: true }
+  })
+}

--- a/test/issues/326/routes/api/autohooks.js
+++ b/test/issues/326/routes/api/autohooks.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.setNotFoundHandler(function (req, reply) {
+    reply.status(404).send({ scope: 'api', url: req.url })
+  })
+}

--- a/test/issues/326/test.js
+++ b/test/issues/326/test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const { after, before, describe, it } = require('node:test')
+const path = require('node:path')
+const Fastify = require('fastify')
+const autoLoad = require('../../../')
+const assert = require('node:assert')
+
+describe('Issue 326: setNotFoundHandler from autohooks must remain under prefixed scope', function () {
+  const app = Fastify()
+
+  before(async function () {
+    app.register(autoLoad, {
+      dir: path.join(__dirname, 'routes', 'api'),
+      autoHooks: true,
+      cascadeHooks: true,
+      options: { prefix: '/api' }
+    })
+
+    await app.ready()
+  })
+
+  after(async function () {
+    await app.close()
+  })
+
+  it('keeps autohooks notFound handler for prefixed paths only', async function () {
+    const prefixed = await app.inject({ method: 'GET', url: '/api/not-exists' })
+    assert.strictEqual(prefixed.statusCode, 404)
+    assert.deepStrictEqual(prefixed.json(), { scope: 'api', url: '/api/not-exists' })
+
+    const root = await app.inject({ method: 'GET', url: '/not-exists' })
+    assert.strictEqual(root.statusCode, 404)
+    assert.notDeepStrictEqual(root.json(), { scope: 'api', url: '/not-exists' })
+    assert.strictEqual(root.json().scope, undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- scope `autohooks` registration under a shared plugin prefix when all plugins in the node resolve to the same prefix
- strip that shared prefix from child plugin registrations inside the scoped context so routes are not double-prefixed
- add a regression test for issue #326 proving `setNotFoundHandler` from `autohooks.js` only affects `/api/*` requests

## Testing
- `npm run unit test/issues/326/test.js test/issues/374/test.js test/issues/376/test.js test/issues/453/test.js`

## Related
Fixes #326