### PR TITLE
fix: match ignorePattern against relative path instead of entry basename

### DIFF
--- a/lib/find-plugins.js
+++ b/lib/find-plugins.js
@@ -87,8 +87,11 @@ function processIndexDirEntryIfExists (pluginTree, { opts, dirEntries, dir, pref
 
 async function processDirContents (pluginTree, { dirEntries, opts, indexDirEntry, prefix, dir, depth, currentDirHooks }) {
   for (const dirEntry of dirEntries) {
-    if (opts.ignorePattern && RegExp(opts.ignorePattern).test(dirEntry.name)) {
-      continue
+    if (opts.ignorePattern) {
+      const entryRelPath = relative(opts.dir, join(dir, dirEntry.name)).replace(/\\/gu, '/')
+      if (RegExp(opts.ignorePattern).test(entryRelPath)) {
+        continue
+      }
     }
 
     const atMaxDepth = Number.isFinite(opts.maxDepth) && opts.maxDepth <= depth

--- a/test/issues/519/routes/private/plugin.js
+++ b/test/issues/519/routes/private/plugin.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = async function (fastify) {
+  fastify.get('/', async () => ({ zone: 'private' }))
+}

--- a/test/issues/519/routes/public/plugin.js
+++ b/test/issues/519/routes/public/plugin.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = async function (fastify) {
+  fastify.get('/', async () => ({ zone: 'public' }))
+}

--- a/test/issues/519/test.js
+++ b/test/issues/519/test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { afterEach, describe, it } = require('node:test')
+const assert = require('node:assert')
+const path = require('node:path')
+const Fastify = require('fastify')
+const autoLoad = require('../../../')
+
+describe('Issue 519: ignorePattern should match against the relative file path, not just the entry basename', function () {
+  let app
+
+  afterEach(async function () {
+    await app.close()
+  })
+
+  it('ignorePattern with a path-component regex skips only the matched subdirectory file', async function () {
+    app = Fastify()
+    app.register(autoLoad, {
+      dir: path.join(__dirname, 'routes'),
+      ignorePattern: /private\/plugin/,
+    })
+    await app.ready()
+
+    const pub = await app.inject({ url: '/public' })
+    assert.strictEqual(pub.statusCode, 200)
+    assert.deepStrictEqual(pub.json(), { zone: 'public' })
+
+    const priv = await app.inject({ url: '/private' })
+    assert.strictEqual(priv.statusCode, 404, 'private route should be excluded by ignorePattern path match')
+  })
+})


### PR DESCRIPTION
When ignorePattern contains a path separator (e.g. /private\/plugin/ to
skip routes/private/plugin.js without affecting routes/public/plugin.js),
it never matched because the check tested the bare directory or file name
rather than the path relative to opts.dir.

matchFilter and ignoreFilter already receive the full relative path with
forward-slash normalisation. This PR applies the same approach to the
ignorePattern check so the two APIs behave consistently.

The change is one line larger than the original: compute the relative
path from opts.dir with the same backslash normalisation used in
accumulatePlugin, then test the pattern against that instead of
dirEntry.name. Existing tests that pass a basename-only pattern (e.g.
/^ignored/) keep working because the relative path still ends with the
basename, so basename-only patterns still match.

A new test in test/issues/519/ covers the failing case: two sibling
subdirectories both containing a plugin.js, ignorePattern set to
/private\/plugin/, verifying that only the private route is excluded.

All 272 unit tests pass, lint is clean, and code coverage remains at 100%.