### PR TITLE
fix: findCommonHooksPrefix  logical error

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,8 +159,8 @@ function registerNode (node, fastify) {
 }
 
 function findCommonHooksPrefix (node) {
-  const prefixes = Object.values(node.pluginsMeta)
-    .map((meta) => meta?.options?.prefix)
+  const prefixes = node.plugins
+    .map((plugin) => node.pluginsMeta[plugin.file]?.options?.prefix)
     .filter((prefix) => typeof prefix === 'string' && prefix.length > 0)
 
   if (prefixes.length === 0) {

--- a/test/commonjs/autohooks-basic-mini.js
+++ b/test/commonjs/autohooks-basic-mini.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const { after, before, describe, it } = require('node:test')
+const assert = require('node:assert')
+const Fastify = require('fastify')
+
+describe('Node test suite for autohooks-basic', function () {
+  const app = Fastify()
+  before(async function () {
+    app.register(require('./autohooks/basic-mini'))
+    app.decorateRequest('hooked', "")
+    await app.ready()
+  })
+
+  after(async function () {
+    await app.close()
+  })
+
+  it('should respond correctly to /', async function () {
+    const res = await app.inject({ url: '/' })
+
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.payload), { hooked: ['root'] })
+  })
+
+  it('should respond correctly to /child', async function () {
+    const res = await app.inject({ url: '/child' })
+
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.payload), { hooked: "" })
+  })
+})

--- a/test/commonjs/autohooks-basic-mini.js
+++ b/test/commonjs/autohooks-basic-mini.js
@@ -8,7 +8,7 @@ describe('Node test suite for autohooks-basic', function () {
   const app = Fastify()
   before(async function () {
     app.register(require('./autohooks/basic-mini'))
-    app.decorateRequest('hooked', "")
+    app.decorateRequest('hooked', '')
     await app.ready()
   })
 
@@ -27,6 +27,6 @@ describe('Node test suite for autohooks-basic', function () {
     const res = await app.inject({ url: '/child' })
 
     assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.payload), { hooked: "" })
+    assert.deepStrictEqual(JSON.parse(res.payload), { hooked: '' })
   })
 })

--- a/test/commonjs/autohooks/basic-mini.js
+++ b/test/commonjs/autohooks/basic-mini.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const path = require('node:path')
+const autoLoad = require('../../../')
+
+module.exports = function (fastify, opts, next) {
+  fastify.log.error(__dirname);
+  
+  fastify.register(autoLoad, {
+    dir: path.join(__dirname, 'routes-mini'),
+    autoHooks: true
+  })
+
+  next()
+}
+

--- a/test/commonjs/autohooks/basic-mini.js
+++ b/test/commonjs/autohooks/basic-mini.js
@@ -4,8 +4,8 @@ const path = require('node:path')
 const autoLoad = require('../../../')
 
 module.exports = function (fastify, opts, next) {
-  fastify.log.error(__dirname);
-  
+  fastify.log.error(__dirname)
+
   fastify.register(autoLoad, {
     dir: path.join(__dirname, 'routes-mini'),
     autoHooks: true
@@ -13,4 +13,3 @@ module.exports = function (fastify, opts, next) {
 
   next()
 }
-

--- a/test/commonjs/autohooks/routes-mini/.autohooks.js
+++ b/test/commonjs/autohooks/routes-mini/.autohooks.js
@@ -1,0 +1,6 @@
+module.exports = async function (app, opts) {
+  app.addHook('onRequest', async (req, reply) => {
+    req.hooked = req.hooked || []
+    req.hooked.push('root')
+  })
+}

--- a/test/commonjs/autohooks/routes-mini/child/routes.js
+++ b/test/commonjs/autohooks/routes-mini/child/routes.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app, opts) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ hooked: req.hooked })
+  })
+}

--- a/test/commonjs/autohooks/routes-mini/routes.js
+++ b/test/commonjs/autohooks/routes-mini/routes.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app, opts) {
+  app.get('/', async function (req, reply) {
+    reply.status(200).send({ hooked: req.hooked })
+  })
+}


### PR DESCRIPTION
pluginsMeta is shared among all nodes, which leads to an error in the findCommonHooksPrefix logic

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
