### PR TITLE
fix: allow autoConfig callbacks without global options

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ function registerPlugin (fastify, meta, allPlugins, parentPlugins = {}) {
   meta.registered = true
 }
 
-function loadPluginOptions (content, overrideConfig) {
+function loadPluginOptions (content, overrideConfig = {}) {
   const pluginConfig = (content.default?.autoConfig) || content.autoConfig || {}
   if (typeof pluginConfig === 'function') {
     const pluginOptions = (fastify) => ({ ...pluginConfig(fastify), ...overrideConfig })

--- a/test/commonjs/auto-config-no-global.js
+++ b/test/commonjs/auto-config-no-global.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const { describe, it } = require('node:test')
+const assert = require('node:assert')
+const path = require('node:path')
+const Fastify = require('fastify')
+const autoLoad = require('../../')
+
+describe('callback autoConfig without global options', function () {
+  it('loads a plugin when the global options object is omitted', async function (t) {
+    const app = Fastify()
+    t.after(() => app.close())
+
+    app.register(autoLoad, {
+      dir: path.join(__dirname, 'auto-config-no-global')
+    })
+    await app.ready()
+
+    const res = await app.inject({ url: '/' })
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(res.json(), { loaded: true })
+  })
+})

--- a/test/commonjs/auto-config-no-global/route.js
+++ b/test/commonjs/auto-config-no-global/route.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = async function (app) {
+  app.get('/', async () => ({ loaded: true }))
+}
+
+module.exports.autoConfig = () => ({})


### PR DESCRIPTION
## Problem

When an autoloaded plugin exports a function-valued `autoConfig` and the autoload call omits the optional global `options` object, registration throws `TypeError: Cannot read properties of undefined (reading 'prefix')`. The documented callback configuration therefore cannot load unless callers provide an otherwise unnecessary empty options object.

## Fix

Default the internal override configuration to an empty object before the callback result is merged. Explicit global options and the existing prefix precedence remain unchanged.

## Tests

- `node --test --test-name-pattern='loads a plugin when the global options object is omitted' test/commonjs/auto-config-no-global.js` — failed before the fix with the expected TypeError; passed after the fix
- `npm test` — passed; borp reported 275 passed, 0 failed, and 100% coverage
- `npm run lint` — passed
- `node --check index.js && node --check test/commonjs/auto-config-no-global.js && node --check test/commonjs/auto-config-no-global/route.js` — passed
- `git diff --check HEAD^ HEAD` — passed

## Compatibility

This changes only the previously failing callback-only configuration. Calls that provide global options retain their existing merge and prefix behavior; no public type, dependency, or package-version change is included.

## Related issue

Independent reproduction; no linked issue. Function-valued `autoConfig` support was previously introduced by historical PR #381.
